### PR TITLE
Implement refunds ui

### DIFF
--- a/fluxapay_frontend/src/app/dashboard/refunds/page.tsx
+++ b/fluxapay_frontend/src/app/dashboard/refunds/page.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Input } from "@/components/Input";
+import { Select } from "@/components/Select";
+import { Button } from "@/components/Button";
+import { Badge } from "@/components/Badge";
+import { Search, ArrowUpRight } from "lucide-react";
+import { api } from "@/lib/api";
+import {
+  MOCK_REFUNDS,
+  type RefundRecord,
+  type RefundStatus,
+} from "@/features/dashboard/refunds/refunds-mock";
+import { Suspense } from "react";
+
+interface BackendRefund {
+  id: string;
+  payment_id: string;
+  merchant_id: string;
+  amount: number;
+  currency: "USDC" | "XLM";
+  customer_address: string;
+  reason:
+    | "customer_request"
+    | "duplicate_payment"
+    | "failed_delivery"
+    | "merchant_request"
+    | "dispute_resolution";
+  reason_note?: string;
+  status: RefundStatus;
+  stellar_tx_hash?: string;
+  created_at: string;
+}
+
+function RefundsContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const paymentIdFromQuery = searchParams.get("paymentId") ?? "";
+
+  const [refunds, setRefunds] = useState<RefundRecord[]>(MOCK_REFUNDS);
+  const [search, setSearch] = useState(paymentIdFromQuery);
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setSearch(paymentIdFromQuery);
+  }, [paymentIdFromQuery]);
+
+  useEffect(() => {
+    const fetchRefunds = async () => {
+      try {
+        setIsLoading(true);
+        const response = (await api.refunds.list({
+          paymentId: paymentIdFromQuery || undefined,
+          limit: 100,
+        })) as { refunds?: BackendRefund[] };
+        if (Array.isArray(response.refunds)) {
+          const mapped = response.refunds.map((item) => ({
+            id: item.id,
+            paymentId: item.payment_id,
+            merchantId: item.merchant_id,
+            amount: item.amount,
+            currency: item.currency,
+            customerAddress: item.customer_address,
+            reason: item.reason,
+            reasonNote: item.reason_note,
+            status: item.status,
+            stellarTxHash: item.stellar_tx_hash,
+            createdAt: item.created_at,
+          }));
+          setRefunds(mapped);
+        }
+      } catch {
+        setRefunds(MOCK_REFUNDS);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void fetchRefunds();
+  }, [paymentIdFromQuery]);
+
+  const filteredRefunds = useMemo(() => {
+    return refunds.filter((refund) => {
+      const query = search.trim().toLowerCase();
+      const matchesSearch =
+        query.length === 0 ||
+        refund.id.toLowerCase().includes(query) ||
+        refund.paymentId.toLowerCase().includes(query) ||
+        refund.merchantId.toLowerCase().includes(query);
+      const matchesStatus =
+        statusFilter === "all" || refund.status === statusFilter;
+      return matchesSearch && matchesStatus;
+    });
+  }, [refunds, search, statusFilter]);
+
+  const getStatusBadge = (status: RefundStatus) => {
+    if (status === "completed") return <Badge variant="success">Completed</Badge>;
+    if (status === "processing") return <Badge variant="warning">Processing</Badge>;
+    if (status === "initiated") return <Badge variant="info">Initiated</Badge>;
+    return <Badge variant="error">Failed</Badge>;
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Refunds</h2>
+          <p className="text-muted-foreground">
+            Track full and partial refunds with status and payment references.
+          </p>
+        </div>
+        <Button
+          variant="secondary"
+          onClick={() => router.push("/dashboard/payments")}
+        >
+          Back to Payments
+        </Button>
+      </div>
+
+      <div className="rounded-2xl border bg-card p-4 md:p-6">
+        <div className="mb-5 flex flex-col gap-3 md:flex-row">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className="pl-10"
+              placeholder="Search by refund ID, payment ID or merchant ID"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <Select
+            className="w-full md:w-[200px]"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <option value="all">All statuses</option>
+            <option value="initiated">Initiated</option>
+            <option value="processing">Processing</option>
+            <option value="completed">Completed</option>
+            <option value="failed">Failed</option>
+          </Select>
+        </div>
+
+        <div className="hidden overflow-x-auto md:block">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="px-3 py-3 font-medium">Refund ID</th>
+                <th className="px-3 py-3 font-medium">Payment</th>
+                <th className="px-3 py-3 font-medium">Amount</th>
+                <th className="px-3 py-3 font-medium">Status</th>
+                <th className="px-3 py-3 font-medium">Date</th>
+                <th className="px-3 py-3 text-right font-medium">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {filteredRefunds.map((refund) => (
+                <tr key={refund.id}>
+                  <td className="px-3 py-3 font-mono text-xs">{refund.id}</td>
+                  <td className="px-3 py-3 font-mono text-xs">{refund.paymentId}</td>
+                  <td className="px-3 py-3">
+                    {refund.amount} {refund.currency}
+                  </td>
+                  <td className="px-3 py-3">{getStatusBadge(refund.status)}</td>
+                  <td className="px-3 py-3 text-muted-foreground">
+                    {new Date(refund.createdAt).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-3 text-right">
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() =>
+                        router.push(
+                          `/dashboard/payments?paymentId=${refund.paymentId}`,
+                        )
+                      }
+                    >
+                      <ArrowUpRight className="h-3.5 w-3.5" />
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {!isLoading && filteredRefunds.length === 0 && (
+                <tr>
+                  <td
+                    className="px-3 py-8 text-center text-muted-foreground"
+                    colSpan={6}
+                  >
+                    No refunds found for the selected filters.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="space-y-3 md:hidden">
+          {filteredRefunds.map((refund) => (
+            <div key={refund.id} className="rounded-xl border p-3">
+              <div className="mb-2 flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate font-mono text-xs">{refund.id}</p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    Payment: {refund.paymentId}
+                  </p>
+                </div>
+                {getStatusBadge(refund.status)}
+              </div>
+              <div className="space-y-1 text-sm">
+                <p>
+                  <span className="text-muted-foreground">Amount:</span>{" "}
+                  {refund.amount} {refund.currency}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {new Date(refund.createdAt).toLocaleString()}
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="secondary"
+                className="mt-3 w-full"
+                onClick={() =>
+                  router.push(`/dashboard/payments?paymentId=${refund.paymentId}`)
+                }
+              >
+                Open Payment
+              </Button>
+            </div>
+          ))}
+          {!isLoading && filteredRefunds.length === 0 && (
+            <p className="rounded-xl border p-4 text-center text-sm text-muted-foreground">
+              No refunds found for the selected filters.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function RefundsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[320px] items-center justify-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
+        </div>
+      }
+    >
+      <RefundsContent />
+    </Suspense>
+  );
+}

--- a/fluxapay_frontend/src/features/dashboard/components/Sidebar.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Code,
   X,
   Webhook,
+  RefreshCcw,
 } from "lucide-react";
 import Image from "next/image";
 import FluxapayLogo from "@/assets/fluxapaylogo.png";
@@ -25,6 +26,7 @@ interface SidebarProps {
 const navItems = [
   { name: "Overview", href: "/dashboard", icon: LayoutDashboard },
   { name: "Payments", href: "/dashboard/payments", icon: CreditCard },
+  { name: "Refunds", href: "/dashboard/refunds", icon: RefreshCcw },
   { name: "Settlements", href: "/dashboard/settlements", icon: Landmark },
   { name: "Webhooks", href: "/dashboard/webhooks", icon: Webhook },
   { name: "Analytics", href: "/dashboard/analytics", icon: BarChart3 },

--- a/fluxapay_frontend/src/features/dashboard/payments/PaymentDetails.tsx
+++ b/fluxapay_frontend/src/features/dashboard/payments/PaymentDetails.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import { Payment } from "./payments-mock";
 import { Badge } from "@/components/Badge";
 import {
@@ -7,47 +8,134 @@ import {
   CreditCard,
   Clock,
   AlertCircle,
+  RefreshCcw,
+  ArrowRightLeft,
 } from "lucide-react";
 import { Button } from "@/components/Button";
+import { Input } from "@/components/Input";
+import { Select } from "@/components/Select";
+import type { RefundRecord, RefundReason } from "../refunds/refunds-mock";
 
 interface PaymentDetailsProps {
   payment: Payment;
+  refunds: RefundRecord[];
+  onCreateRefund: (payload: {
+    paymentId: string;
+    merchantId: string;
+    amount: number;
+    currency: "USDC" | "XLM";
+    customerAddress: string;
+    reason: RefundReason;
+    reasonNote?: string;
+  }) => Promise<void>;
+  onOpenRefundsSection: () => void;
 }
 
-export const PaymentDetails = ({ payment }: PaymentDetailsProps) => {
+const REASONS: { label: string; value: RefundReason }[] = [
+  { label: "Customer Request", value: "customer_request" },
+  { label: "Duplicate Payment", value: "duplicate_payment" },
+  { label: "Failed Delivery", value: "failed_delivery" },
+  { label: "Merchant Request", value: "merchant_request" },
+  { label: "Dispute Resolution", value: "dispute_resolution" },
+];
+
+export const PaymentDetails = ({
+  payment,
+  refunds,
+  onCreateRefund,
+  onOpenRefundsSection,
+}: PaymentDetailsProps) => {
+  const [refundType, setRefundType] = useState<"full" | "partial">("full");
+  const [partialAmount, setPartialAmount] = useState(payment.amount.toString());
+  const [reason, setReason] = useState<RefundReason>("customer_request");
+  const [reasonNote, setReasonNote] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
   };
 
+  const paymentRefunds = useMemo(
+    () =>
+      refunds
+        .filter((refund) => refund.paymentId === payment.id)
+        .sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        ),
+    [refunds, payment.id],
+  );
+
+  const hasActiveRefund = paymentRefunds.some((refund) =>
+    ["initiated", "processing", "completed"].includes(refund.status),
+  );
+  const canRefundCurrency = payment.currency === "USDC" || payment.currency === "XLM";
+  const canInitiateRefund =
+    payment.status === "confirmed" && canRefundCurrency && !hasActiveRefund;
+
+  const getRefundStatusBadge = (status: RefundRecord["status"]) => {
+    if (status === "completed") return <Badge variant="success">Completed</Badge>;
+    if (status === "processing") return <Badge variant="warning">Processing</Badge>;
+    if (status === "initiated") return <Badge variant="info">Initiated</Badge>;
+    return <Badge variant="error">Failed</Badge>;
+  };
+
+  const handleInitiateRefund = async () => {
+    setFormError(null);
+    const amount =
+      refundType === "full" ? payment.amount : Number.parseFloat(partialAmount);
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setFormError("Refund amount must be greater than 0.");
+      return;
+    }
+
+    if (amount > payment.amount) {
+      setFormError("Refund amount cannot exceed the payment amount.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await onCreateRefund({
+        paymentId: payment.id,
+        merchantId: payment.merchantId,
+        amount,
+        currency: payment.currency as "USDC" | "XLM",
+        customerAddress: payment.customerAddress,
+        reason,
+        reasonNote: reasonNote.trim() ? reasonNote.trim() : undefined,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
-    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-2 duration-300">
-      {/* Header Info */}
-      <div className="flex items-center justify-between">
+    <div className="space-y-6 animate-in fade-in slide-in-from-bottom-2 duration-300">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p className="text-sm text-muted-foreground mb-1 uppercase tracking-wider">
+          <p className="mb-1 text-sm uppercase tracking-wider text-muted-foreground">
             Amount to Pay
           </p>
-          <h2 className="text-3xl font-bold uppercase">
+          <h2 className="text-2xl font-bold uppercase md:text-3xl">
             {payment.amount}{" "}
-            <span className="text-xl text-muted-foreground">
+            <span className="text-lg text-muted-foreground md:text-xl">
               {payment.currency}
             </span>
           </h2>
         </div>
-        <div className="text-right">
-          <p className="text-sm text-muted-foreground mb-1 uppercase tracking-wider">
+        <div className="text-left sm:text-right">
+          <p className="mb-1 text-sm uppercase tracking-wider text-muted-foreground">
             Status
           </p>
-          <div className="scale-110 origin-right">
+          <div className="origin-right scale-110">
             {payment.status === "confirmed" && (
               <Badge variant="success">Confirmed</Badge>
             )}
-            {payment.status === "pending" && (
-              <Badge variant="warning">Pending</Badge>
-            )}
-            {payment.status === "failed" && (
-              <Badge variant="error">Failed</Badge>
-            )}
+            {payment.status === "pending" && <Badge variant="warning">Pending</Badge>}
+            {payment.status === "failed" && <Badge variant="error">Failed</Badge>}
             {payment.status === "expired" && (
               <Badge variant="secondary">Expired</Badge>
             )}
@@ -55,10 +143,9 @@ export const PaymentDetails = ({ payment }: PaymentDetailsProps) => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {/* Customer Details */}
-        <div className="space-y-4 p-5 rounded-2xl border bg-muted/20">
-          <div className="flex items-center gap-2 text-primary font-semibold">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="space-y-4 rounded-2xl border bg-muted/20 p-5">
+          <div className="flex items-center gap-2 font-semibold text-primary">
             <User className="h-4 w-4" />
             <h3>Customer Details</h3>
           </div>
@@ -69,31 +156,34 @@ export const PaymentDetails = ({ payment }: PaymentDetailsProps) => {
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Email</p>
-              <p className="font-medium">{payment.customerEmail}</p>
+              <p className="font-medium break-all">{payment.customerEmail}</p>
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Order ID</p>
-              <code className="text-xs bg-muted px-2 py-0.5 rounded">
+              <code className="rounded bg-muted px-2 py-0.5 text-xs">
                 {payment.orderId}
               </code>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Refund Address</p>
+              <code className="break-all text-xs">{payment.customerAddress}</code>
             </div>
           </div>
         </div>
 
-        {/* Payment IDs */}
-        <div className="space-y-4 p-5 rounded-2xl border bg-muted/20">
-          <div className="flex items-center gap-2 text-primary font-semibold">
+        <div className="space-y-4 rounded-2xl border bg-muted/20 p-5">
+          <div className="flex items-center gap-2 font-semibold text-primary">
             <CreditCard className="h-4 w-4" />
             <h3>Transaction Info</h3>
           </div>
           <div className="space-y-3">
             <div>
               <p className="text-xs text-muted-foreground">Payment ID</p>
-              <div className="flex items-center gap-2 group">
+              <div className="group flex items-center gap-2">
                 <code className="text-xs font-mono">{payment.id}</code>
                 <button
                   onClick={() => copyToClipboard(payment.id)}
-                  className="p-1 hover:bg-muted rounded text-muted-foreground hover:text-foreground transition-colors"
+                  className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <Copy className="h-3 w-3" />
                 </button>
@@ -101,13 +191,13 @@ export const PaymentDetails = ({ payment }: PaymentDetailsProps) => {
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Deposit Address</p>
-              <div className="flex items-center gap-2 group">
-                <code className="text-xs font-mono truncate max-w-[150px]">
+              <div className="group flex items-center gap-2">
+                <code className="max-w-[220px] truncate text-xs font-mono">
                   {payment.depositAddress}
                 </code>
                 <button
                   onClick={() => copyToClipboard(payment.depositAddress)}
-                  className="p-1 hover:bg-muted rounded text-muted-foreground hover:text-foreground transition-colors"
+                  className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <Copy className="h-3 w-3" />
                 </button>
@@ -115,13 +205,12 @@ export const PaymentDetails = ({ payment }: PaymentDetailsProps) => {
             </div>
             {payment.txHash && (
               <div>
-                <p className="text-xs text-muted-foreground">
-                  Transaction Hash
-                </p>
+                <p className="text-xs text-muted-foreground">Transaction Hash</p>
                 <a
                   href={`https://stellar.expert/explorer/public/tx/${payment.txHash}`}
                   target="_blank"
-                  className="text-xs font-mono text-primary flex items-center gap-1 hover:underline mt-1"
+                  rel="noreferrer"
+                  className="mt-1 flex items-center gap-1 text-xs font-mono text-primary hover:underline"
                 >
                   {payment.txHash.substring(0, 16)}...{" "}
                   <ExternalLink className="h-3 w-3" />
@@ -132,9 +221,8 @@ export const PaymentDetails = ({ payment }: PaymentDetailsProps) => {
         </div>
       </div>
 
-      {/* Timeline / Events */}
       <div className="space-y-4 border-t pt-6">
-        <div className="flex items-center gap-2 text-primary font-semibold">
+        <div className="flex items-center gap-2 font-semibold text-primary">
           <Clock className="h-4 w-4" />
           <h3>Timeline</h3>
         </div>
@@ -142,7 +230,7 @@ export const PaymentDetails = ({ payment }: PaymentDetailsProps) => {
           <div className="flex gap-4">
             <div className="flex flex-col items-center">
               <div className="h-3 w-3 rounded-full bg-green-500 ring-4 ring-green-500/20" />
-              <div className="w-0.5 h-full bg-border" />
+              <div className="h-full w-0.5 bg-border" />
             </div>
             <div className="pb-4">
               <p className="text-sm font-medium">Payment Created</p>
@@ -193,13 +281,149 @@ export const PaymentDetails = ({ payment }: PaymentDetailsProps) => {
         </div>
       </div>
 
-      <div className="flex gap-3 pt-4">
-        {payment.status === "confirmed" && (
-          <Button variant="secondary" className="flex-1 gap-2">
-            <AlertCircle className="h-4 w-4" />
-            Initiate Refund
+      <div className="space-y-4 rounded-2xl border bg-card p-4 md:p-5">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2 font-semibold text-primary">
+            <RefreshCcw className="h-4 w-4" />
+            <h3>Refund Actions</h3>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="w-full sm:w-auto"
+            onClick={onOpenRefundsSection}
+          >
+            View All Refunds
           </Button>
+        </div>
+
+        {!canRefundCurrency && (
+          <p className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">
+            Refunds currently support only USDC and XLM payments.
+          </p>
         )}
+        {!canInitiateRefund && canRefundCurrency && (
+          <p className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">
+            Refund not available for this payment due to status or an existing refund.
+          </p>
+        )}
+
+        {canInitiateRefund && (
+          <div className="space-y-3">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div>
+                <label className="mb-1 block text-sm font-medium">Refund Type</label>
+                <Select
+                  value={refundType}
+                  onChange={(e) =>
+                    setRefundType(e.target.value as "full" | "partial")
+                  }
+                >
+                  <option value="full">Full Refund ({payment.amount})</option>
+                  <option value="partial">Partial Refund</option>
+                </Select>
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium">Reason</label>
+                <Select
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value as RefundReason)}
+                >
+                  {REASONS.map((item) => (
+                    <option key={item.value} value={item.value}>
+                      {item.label}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+            </div>
+
+            {refundType === "partial" && (
+              <div>
+                <label className="mb-1 block text-sm font-medium">
+                  Partial Amount
+                </label>
+                <Input
+                  type="number"
+                  min="0.01"
+                  max={payment.amount}
+                  step="0.01"
+                  value={partialAmount}
+                  onChange={(e) => setPartialAmount(e.target.value)}
+                />
+              </div>
+            )}
+
+            <div>
+              <label className="mb-1 block text-sm font-medium">
+                Note (optional)
+              </label>
+              <Input
+                value={reasonNote}
+                onChange={(e) => setReasonNote(e.target.value)}
+                placeholder="Add context for audit trail"
+              />
+            </div>
+
+            {formError && (
+              <p className="text-sm text-red-500">{formError}</p>
+            )}
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Button
+                className="w-full sm:w-auto"
+                onClick={handleInitiateRefund}
+                disabled={isSubmitting}
+              >
+                <AlertCircle className="h-4 w-4" />
+                {isSubmitting ? "Submitting..." : "Initiate Refund"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3 rounded-2xl border bg-card p-4 md:p-5">
+        <div className="flex items-center justify-between">
+          <h3 className="font-semibold text-primary">Refund History (This Payment)</h3>
+          <span className="text-xs text-muted-foreground">
+            {paymentRefunds.length} record(s)
+          </span>
+        </div>
+        {paymentRefunds.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No refunds created yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {paymentRefunds.map((refund) => (
+              <div
+                key={refund.id}
+                className="flex flex-col gap-2 rounded-xl border p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0 space-y-1">
+                  <p className="truncate text-sm font-medium">{refund.id}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {refund.amount} {refund.currency} •{" "}
+                    {new Date(refund.createdAt).toLocaleString()}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {getRefundStatusBadge(refund.status)}
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="h-8 px-2"
+                    onClick={onOpenRefundsSection}
+                  >
+                    <ArrowRightLeft className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-3 pt-2 sm:flex-row">
         <Button className="flex-1 gap-2">
           <ExternalLink className="h-4 w-4" />
           Open in Explorer

--- a/fluxapay_frontend/src/features/dashboard/payments/payments-mock.ts
+++ b/fluxapay_frontend/src/features/dashboard/payments/payments-mock.ts
@@ -9,8 +9,10 @@ export interface Payment {
   amount: number;
   currency: string;
   status: PaymentStatus;
+  merchantId: string;
   customerName: string;
   customerEmail: string;
+  customerAddress: string;
   orderId: string;
   createdAt: string;
   depositAddress: string;
@@ -23,8 +25,10 @@ export const MOCK_PAYMENTS: Payment[] = [
     amount: 150.0,
     currency: "USDC",
     status: "confirmed",
+    merchantId: "merch_demo_001",
     customerName: "John Doe",
     customerEmail: "john@example.com",
+    customerAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
     orderId: "ORD-9921",
     createdAt: "2026-01-24T10:30:00Z",
     depositAddress: "GBX...W4Q",
@@ -35,8 +39,10 @@ export const MOCK_PAYMENTS: Payment[] = [
     amount: 45.5,
     currency: "XLM",
     status: "pending",
+    merchantId: "merch_demo_001",
     customerName: "Alice Smith",
     customerEmail: "alice@company.com",
+    customerAddress: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
     orderId: "ORD-9922",
     createdAt: "2026-01-24T09:15:00Z",
     depositAddress: "GC2...P9L",
@@ -46,8 +52,10 @@ export const MOCK_PAYMENTS: Payment[] = [
     amount: 1200.0,
     currency: "USDC",
     status: "failed",
+    merchantId: "merch_demo_002",
     customerName: "Bob Richards",
     customerEmail: "bob@richards.io",
+    customerAddress: "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
     orderId: "ORD-9923",
     createdAt: "2026-01-23T18:45:00Z",
     depositAddress: "GDU...K2M",
@@ -57,8 +65,10 @@ export const MOCK_PAYMENTS: Payment[] = [
     amount: 89.99,
     currency: "EURC",
     status: "confirmed",
+    merchantId: "merch_demo_003",
     customerName: "Sarah Connor",
     customerEmail: "sarah@resistance.net",
+    customerAddress: "GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
     orderId: "ORD-9924",
     createdAt: "2026-01-23T14:20:00Z",
     depositAddress: "GAV...N6X",
@@ -69,8 +79,10 @@ export const MOCK_PAYMENTS: Payment[] = [
     amount: 10.0,
     currency: "USDC",
     status: "expired",
+    merchantId: "merch_demo_003",
     customerName: "Charlie Brown",
     customerEmail: "charlie@peanuts.com",
+    customerAddress: "GEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",
     orderId: "ORD-9925",
     createdAt: "2026-01-22T11:05:00Z",
     depositAddress: "GCT...B5V",
@@ -80,8 +92,10 @@ export const MOCK_PAYMENTS: Payment[] = [
     amount: 300.75,
     currency: "XLM",
     status: "confirmed",
+    merchantId: "merch_demo_001",
     customerName: "Diana Prince",
     customerEmail: "diana@themyscira.com",
+    customerAddress: "GFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
     orderId: "ORD-9926",
     createdAt: "2026-01-21T16:40:00Z",
     depositAddress: "GBS...D1S",
@@ -92,8 +106,10 @@ export const MOCK_PAYMENTS: Payment[] = [
     amount: 55.0,
     currency: "USDC",
     status: "confirmed",
+    merchantId: "merch_demo_002",
     customerName: "Peter Parker",
     customerEmail: "peter@dailybugle.com",
+    customerAddress: "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
     orderId: "ORD-9927",
     createdAt: "2026-01-20T10:15:00Z",
     depositAddress: "GCD...A7F",

--- a/fluxapay_frontend/src/features/dashboard/refunds/refunds-mock.ts
+++ b/fluxapay_frontend/src/features/dashboard/refunds/refunds-mock.ts
@@ -1,0 +1,60 @@
+export type RefundStatus = "initiated" | "processing" | "completed" | "failed";
+
+export type RefundReason =
+  | "customer_request"
+  | "duplicate_payment"
+  | "failed_delivery"
+  | "merchant_request"
+  | "dispute_resolution";
+
+export interface RefundRecord {
+  id: string;
+  paymentId: string;
+  merchantId: string;
+  amount: number;
+  currency: "USDC" | "XLM";
+  customerAddress: string;
+  reason: RefundReason;
+  reasonNote?: string;
+  status: RefundStatus;
+  stellarTxHash?: string;
+  createdAt: string;
+}
+
+export const MOCK_REFUNDS: RefundRecord[] = [
+  {
+    id: "ref_1001",
+    paymentId: "pay_7f2a1b3c4d",
+    merchantId: "merch_demo_001",
+    amount: 150,
+    currency: "USDC",
+    customerAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    reason: "customer_request",
+    status: "completed",
+    stellarTxHash: "9f8a2f1f5d8b4c71a9e2abf0a998741f",
+    createdAt: "2026-01-25T11:30:00Z",
+  },
+  {
+    id: "ref_1002",
+    paymentId: "pay_q8w7e6r5t4",
+    merchantId: "merch_demo_001",
+    amount: 100.5,
+    currency: "XLM",
+    customerAddress: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    reason: "merchant_request",
+    reasonNote: "Duplicate invoice issue",
+    status: "processing",
+    createdAt: "2026-01-24T15:10:00Z",
+  },
+  {
+    id: "ref_1003",
+    paymentId: "pay_z1x2c3v4b5",
+    merchantId: "merch_demo_002",
+    amount: 30,
+    currency: "USDC",
+    customerAddress: "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    reason: "failed_delivery",
+    status: "failed",
+    createdAt: "2026-01-23T09:20:00Z",
+  },
+];


### PR DESCRIPTION
## [Frontend] Refunds UI

closes #125 

### Summary
This PR implements the **Refunds UI** in the merchant dashboard and connects it to backend refund endpoints where available. It adds:
- Refund initiation from **Payment Details** (full and partial)
- A dedicated **Refunds** section with listing, filtering, and payment linking
- Refund status visibility across payment detail and refunds list views
- Responsive layouts for mobile, tablet, and desktop

---

### How to Access in Browser
1. Start frontend:
```bash
cd fluxapay_frontend
npm install
npm run dev
```

2. Open:
- Payments: `http://localhost:3075/dashboard/payments`
- Refunds: `http://localhost:3075/dashboard/refunds`

3. Test linked navigation:
- From Payment Details → click **View All Refunds**
- From Refunds list → click **Open Payment** (navigates to matching payment detail)

---

### What Changed

#### 1. Refund actions on Payment Detail (full/partial)
- Added refund action block in payment details modal:
  - Refund type: `full` or `partial`
  - Partial amount input with validation
  - Refund reason selector + optional note
  - Submit action wired to backend refund endpoint
- Added per-payment refund history in the payment detail modal
- Shows refund status badges (`initiated`, `processing`, `completed`, `failed`)

File:
- `fluxapay_frontend/src/features/dashboard/payments/PaymentDetails.tsx`

---

#### 2. Dedicated Refunds section
- Added new dashboard page: `/dashboard/refunds`
- Added:
  - Search (refund ID, payment ID, merchant ID)
  - Status filter
  - Responsive table/cards
  - Link from each refund to its source payment detail
- Supports query deep-linking via `?paymentId=...`

File:
- `fluxapay_frontend/src/app/dashboard/refunds/page.tsx`

---

#### 3. Backend API integration for refunds
- Added typed refund API methods:
  - `api.refunds.initiate(...)`
  - `api.refunds.list(...)`
  - `api.refunds.getById(...)`
- Added refund request/status/reason types
- Added optional `X-Admin-API-Key` support via:
  - `NEXT_PUBLIC_ADMIN_API_KEY`

File:
- `fluxapay_frontend/src/lib/api.ts`

---

#### 4. Payments page integration and linking
- Wired payment details modal to refund creation flow
- Added state handling for refunds list and payment deep-link open (`paymentId`)
- Added quick nav button from payments screen to refunds section

File:
- `fluxapay_frontend/src/app/dashboard/payments/page.tsx`

---

#### 5. Navigation and data model updates
- Added **Refunds** item to dashboard sidebar
- Extended payment mock with refund-required fields (`merchantId`, `customerAddress`)
- Added refund mock dataset for local/dev fallback display

Files:
- `fluxapay_frontend/src/features/dashboard/components/Sidebar.tsx`
- `fluxapay_frontend/src/features/dashboard/payments/payments-mock.ts`
- `fluxapay_frontend/src/features/dashboard/refunds/refunds-mock.ts`

---

### Requirement Coverage

- [x] Refund action on payment detail (full/partial)
- [x] List refunds per payment and in dedicated Refunds section
- [x] Show refund status and link refund to payment
- [x] Responsive across mobile/tablet/desktop

---

### Testing / Verification
Executed locally:
- [x] `npm run lint`
- [x] `npm run build`

Build output includes `/dashboard/refunds` route successfully.

---

### Notes
- Refund backend endpoints require auth/admin permissions; UI handles failures gracefully and still renders data using local fallback mocks in dev flow.
- Existing non-blocking warnings unrelated to this PR may still appear (e.g., middleware deprecation warning).