### PR TITLE
add the core xlm reserve recovery...

### DIFF
--- a/fluxapay_backend/src/services/funderMonitor.service.ts
+++ b/fluxapay_backend/src/services/funderMonitor.service.ts
@@ -1,0 +1,47 @@
+import { Horizon, Keypair } from "@stellar/stellar-sdk";
+
+export interface FunderBalanceStatus {
+  publicKey: string;
+  xlmBalance: number;
+  thresholdXlm: number;
+  ok: boolean;
+}
+
+/**
+ * funderMonitor.service.ts
+ *
+ * Technical-debt utility for monitoring the funder wallet balance used to create
+ * derived payment accounts.
+ */
+export class FunderMonitorService {
+  private server: Horizon.Server;
+  private funderKeypair: Keypair;
+
+  constructor() {
+    const horizonUrl = process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
+    this.server = new Horizon.Server(horizonUrl);
+
+    const funderSecret = process.env.FUNDER_SECRET_KEY;
+    if (!funderSecret) {
+      throw new Error("FUNDER_SECRET_KEY is required");
+    }
+    this.funderKeypair = Keypair.fromSecret(funderSecret);
+  }
+
+  public async getBalanceStatus(): Promise<FunderBalanceStatus> {
+    const thresholdXlm = parseFloat(process.env.FUNDER_LOW_BALANCE_THRESHOLD_XLM || "20");
+
+    const account = await this.server.loadAccount(this.funderKeypair.publicKey());
+    const nativeBal = account.balances.find((b: any) => b.asset_type === "native");
+    const xlmBalance = nativeBal ? parseFloat(nativeBal.balance) : 0;
+
+    return {
+      publicKey: this.funderKeypair.publicKey(),
+      xlmBalance,
+      thresholdXlm,
+      ok: xlmBalance >= thresholdXlm,
+    };
+  }
+}
+
+export const funderMonitorService = new FunderMonitorService();


### PR DESCRIPTION
## Summary

Implements **Issue #92: XLM Reserve & Funder Replenishment** by enhancing the sweep flow to recover trapped XLM reserves from derived payment accounts and adding monitoring for the funder wallet balance used to provision payment accounts.

## What Changed

### 1) Reserve Recovery (Account Merge after USDC Sweep)
- Updated `fluxapay_backend/src/services/sweep.service.ts` to optionally append an `accountMerge` operation **after** the USDC sweep payment.
- This returns remaining XLM (including the base reserve) from each derived payment account back to the funder wallet.
- Controlled via:
  - `SweepOptions.enableAccountMerge` (per-run), or
  - `SWEEP_ENABLE_ACCOUNT_MERGE=true` (env)

### 2) Funder Balance Monitoring (Replenishment Alerting)
- Added `fluxapay_backend/src/services/funderMonitor.service.ts`
  - Loads the funder account using `FUNDER_SECRET_KEY`
  - Reads the native XLM balance
  - Compares against a configurable threshold
- Updated `fluxapay_backend/src/services/cron.service.ts` to run a scheduled job that warns if funder balance is below threshold.

## New/Updated Environment Variables

### Sweep / Reserve Recovery
- `SWEEP_ENABLE_ACCOUNT_MERGE` — set to `"true"` to enable reserve recovery via account merge (default: off)
- `FUNDER_PUBLIC_KEY` — required for account merge destination when merge is enabled

### Funder Monitoring
- `FUNDER_LOW_BALANCE_THRESHOLD_XLM` — XLM threshold for warnings (default: `20`)
- `FUNDER_MONITOR_CRON` — schedule for funder balance checks (default: `*/10 * * * *`)
- `DISABLE_FUNDER_MONITOR_CRON` — set to `"true"` to disable funder monitoring cron job

## Notes
- Sweep continues to submit **one transaction per payment address** for safety; when enabled, the same transaction includes both:
  1) USDC payment to the master vault
  2) `accountMerge` back to the funder wallet
- If `SWEEP_ENABLE_ACCOUNT_MERGE=true` but `FUNDER_PUBLIC_KEY` is missing, the system logs a warning and skips

Closes #92 