### PR TITLE
fix: add merchantId gaurd to getPayment

### DIFF
--- a/fluxapay_backend/src/controllers/payment.controller.ts
+++ b/fluxapay_backend/src/controllers/payment.controller.ts
@@ -53,6 +53,10 @@ export const getPayments = async (req: Request, res: Response) => {
     const authReq = req as AuthRequest;
     const merchantId = authReq.merchantId;
 
+    if (!merchantId) {
+      return res.status(401).json({ error: "Unauthorized: Merchant ID missing" });
+    }
+
     // 1. Destructure with explicit type casting immediately
     const query = req.query as Record<string, unknown>;
 


### PR DESCRIPTION
## Fix: Add authentication guard to GET /api/payments and GET /api/payments/export

### Problem
The `getPayments` controller (used by both `GET /api/payments` and `GET /api/payments/export`) did not validate that `merchantId` was present before querying the database. If `merchantId` were ever `undefined`, Prisma would ignore the filter and return **all merchants' payments** — a potential data leak.

### What changed
Added a `merchantId` guard in `getPayments` (`payment.controller.ts`) that returns `401 Unauthorized` if the merchant ID is missing. This matches the existing pattern already used in `createPayment`.

### Testing
- `npm run build` — Passes
- `npm run lint` — Passes (0 errors)
- `npm test` — 12 suites fail (pre-existing `@types/jest` missing issue, unrelated to this change)

### closes 
close #139 