### PR TITLE
feat: implement  Merchant Registry on signup

### DIFF
--- a/fluxapay_backend/prisma/schema.prisma
+++ b/fluxapay_backend/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Merchant {
   api_key_last_four   String?
   bankAccount         BankAccount?
   subscriptions       MerchantSubscription[]
+  manualInterventions ManualIntervention[]
 }
 
 model Plan {
@@ -498,4 +499,31 @@ enum AuditEntityType {
   system_config
   sweep_operation
   settlement_batch
+}
+
+model ManualIntervention {
+  id               String                   @id @default(cuid())
+  merchant         Merchant                 @relation(fields: [merchantId], references: [id])
+  merchantId       String
+  issue_type       InterventionIssueType
+  description      String
+  status           InterventionStatus       @default(pending)
+  resolution_notes String?
+  resolved_at      DateTime?
+  created_at       DateTime                 @default(now())
+  updated_at       DateTime                 @updatedAt
+
+  @@index([merchantId])
+  @@index([status])
+}
+
+enum InterventionIssueType {
+  onchain_registration_failed
+  other
+}
+
+enum InterventionStatus {
+  pending
+  resolving
+  resolved
 }

--- a/fluxapay_backend/src/services/merchantRegistry.service.ts
+++ b/fluxapay_backend/src/services/merchantRegistry.service.ts
@@ -1,122 +1,181 @@
-import { Keypair, nativeToScVal, rpc, TransactionBuilder, Networks, Contract } from '@stellar/stellar-sdk';
-import { isDevEnv } from '../helpers/env.helper';
+import {
+  Keypair,
+  nativeToScVal,
+  rpc,
+  TransactionBuilder,
+  Networks,
+  Contract,
+} from "@stellar/stellar-sdk";
+import { isDevEnv } from "../helpers/env.helper";
+import { PrismaClient } from "../generated/client/client";
+
+const prisma = new PrismaClient();
 
 export class MerchantRegistryService {
-    private rpcUrl: string;
-    private networkPassphrase: string;
-    private contractId: string;
-    private adminKeypair: Keypair;
-    private server: rpc.Server;
+  private rpcUrl: string;
+  private networkPassphrase: string;
+  private contractId: string;
+  private adminKeypair: Keypair;
+  private server: rpc.Server;
 
-    constructor() {
-        this.rpcUrl = process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
-        this.networkPassphrase = process.env.SOROBAN_NETWORK_PASSPHRASE || Networks.TESTNET;
-        this.contractId = process.env.MERCHANT_REGISTRY_CONTRACT_ID || '';
+  constructor() {
+    this.rpcUrl =
+      process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
+    this.networkPassphrase =
+      process.env.SOROBAN_NETWORK_PASSPHRASE || Networks.TESTNET;
+    this.contractId = process.env.MERCHANT_REGISTRY_CONTRACT_ID || "";
 
-        const adminSecret = process.env.ADMIN_SECRET_KEY;
-        if (adminSecret) {
-            this.adminKeypair = Keypair.fromSecret(adminSecret);
-        } else {
-            // Create a random one for dev/fallback if missing, though it won't actually have authorization on mainnet
-            this.adminKeypair = Keypair.random();
-            if (isDevEnv()) {
-                console.warn("ADMIN_SECRET_KEY not set. Using random keypair. Contract calls will likely fail.");
-            }
-        }
-
-        this.server = new rpc.Server(this.rpcUrl);
+    const adminSecret = process.env.ADMIN_SECRET_KEY;
+    if (adminSecret) {
+      this.adminKeypair = Keypair.fromSecret(adminSecret);
+    } else {
+      // Create a random one for dev/fallback if missing, though it won't actually have authorization on mainnet
+      this.adminKeypair = Keypair.random();
+      if (isDevEnv()) {
+        console.warn(
+          "ADMIN_SECRET_KEY not set. Using random keypair. Contract calls will likely fail.",
+        );
+      }
     }
 
-    /**
-     * Registers a merchant on-chain via the Soroban Smart Contract.
-     * Includes an automatic retry mechanism for robustness.
-     */
-    public async register_merchant(merchantId: string, businessName: string, settlementCurrency: string): Promise<boolean> {
-        if (!this.contractId) {
-            console.warn("MERCHANT_REGISTRY_CONTRACT_ID is not configured. Skipping on-chain registration.");
-            return false;
-        }
+    this.server = new rpc.Server(this.rpcUrl);
+  }
 
-        const MAX_RETRIES = 3;
-        let attempt = 0;
-        const baseDelay = 1000;
-
-        while (attempt < MAX_RETRIES) {
-            try {
-                await this.invokeRegisterContract(merchantId, businessName, settlementCurrency);
-                if (isDevEnv()) {
-                    console.log(`Successfully registered merchant ${merchantId} on-chain.`);
-                }
-                return true;
-            } catch (error) {
-                attempt++;
-                let errorMessage = 'Unknown error';
-                if (error instanceof Error) errorMessage = error.message;
-
-                console.error(`Attempt ${attempt} to register merchant ${merchantId} on-chain failed:`, errorMessage);
-
-                if (attempt >= MAX_RETRIES) {
-                    // Log to manual intervention queue
-                    this.logToManualInterventionQueue(merchantId, errorMessage);
-                    return false;
-                }
-
-                // Exponential backoff
-                await new Promise(resolve => setTimeout(resolve, baseDelay * Math.pow(2, attempt - 1)));
-            }
-        }
-        return false;
+  /**
+   * Registers a merchant on-chain via the Soroban Smart Contract.
+   * Includes an automatic retry mechanism for robustness.
+   * Throws an error if we exceed max retries.
+   */
+  public async register_merchant(
+    merchantId: string,
+    businessName: string,
+    settlementCurrency: string,
+  ): Promise<boolean> {
+    if (!this.contractId) {
+      console.warn(
+        "MERCHANT_REGISTRY_CONTRACT_ID is not configured. Skipping on-chain registration.",
+      );
+      return false;
     }
 
-    private async invokeRegisterContract(merchantId: string, businessName: string, settlementCurrency: string) {
-        const contract = new Contract(this.contractId);
+    const MAX_RETRIES = 3;
+    let attempt = 0;
+    const baseDelay = 1000;
 
-        // Prepare arguments: merchant_id, business_name, settlement_currency
-        const args = [
-            nativeToScVal(merchantId, { type: 'string' }),
-            nativeToScVal(businessName, { type: 'string' }),
-            nativeToScVal(settlementCurrency, { type: 'symbol' })
-        ];
-
-        const sourceAccount = await this.server.getAccount(this.adminKeypair.publicKey());
-
-        const builder = new TransactionBuilder(sourceAccount, {
-            fee: '100000',
-            networkPassphrase: this.networkPassphrase,
-        });
-
-        const tx = builder
-            .addOperation(contract.call('register_merchant', ...args))
-            .setTimeout(30)
-            .build();
-
-        const preparedTx = await this.server.prepareTransaction(tx) as any;
-
-        preparedTx.sign(this.adminKeypair);
-
-        const sendTxResponse = await this.server.sendTransaction(preparedTx);
-
-        if (sendTxResponse.status === 'ERROR') {
-            throw new Error(`Transaction submission failed: ${JSON.stringify(sendTxResponse)}`);
+    while (attempt < MAX_RETRIES) {
+      try {
+        await this.invokeRegisterContract(
+          merchantId,
+          businessName,
+          settlementCurrency,
+        );
+        if (isDevEnv()) {
+          console.log(
+            `Successfully registered merchant ${merchantId} on-chain.`,
+          );
         }
-
-        // Wait for the transaction to be processed
-        let txResponse = await this.server.getTransaction(sendTxResponse.hash);
-
-        let retries = 0;
-        while (txResponse.status === 'NOT_FOUND' && retries < 10) {
-            await new Promise(resolve => setTimeout(resolve, 2000));
-            txResponse = await this.server.getTransaction(sendTxResponse.hash);
-            retries++;
-        }
-
         return true;
+      } catch (error) {
+        attempt++;
+        let errorMessage = "Unknown error";
+        if (error instanceof Error) errorMessage = error.message;
+
+        console.error(
+          `Attempt ${attempt} to register merchant ${merchantId} on-chain failed:`,
+          errorMessage,
+        );
+
+        if (attempt >= MAX_RETRIES) {
+          await this.logToManualInterventionQueue(merchantId, errorMessage);
+          throw new Error(
+            `Max retries reached for on-chain registration: ${errorMessage}`,
+          );
+        }
+
+        // Exponential backoff
+        await new Promise((resolve) =>
+          setTimeout(resolve, baseDelay * Math.pow(2, attempt - 1)),
+        );
+      }
+    }
+    return false;
+  }
+
+  private async invokeRegisterContract(
+    merchantId: string,
+    businessName: string,
+    settlementCurrency: string,
+  ) {
+    const contract = new Contract(this.contractId);
+
+    // Prepare arguments: merchant_id, business_name, settlement_currency
+    const args = [
+      nativeToScVal(merchantId, { type: "string" }),
+      nativeToScVal(businessName, { type: "string" }),
+      nativeToScVal(settlementCurrency, { type: "symbol" }),
+    ];
+
+    const sourceAccount = await this.server.getAccount(
+      this.adminKeypair.publicKey(),
+    );
+
+    const builder = new TransactionBuilder(sourceAccount, {
+      fee: "100000",
+      networkPassphrase: this.networkPassphrase,
+    });
+
+    const tx = builder
+      .addOperation(contract.call("register_merchant", ...args))
+      .setTimeout(30)
+      .build();
+
+    const preparedTx = (await this.server.prepareTransaction(tx)) as any;
+
+    preparedTx.sign(this.adminKeypair);
+
+    const sendTxResponse = await this.server.sendTransaction(preparedTx);
+
+    if (sendTxResponse.status === "ERROR") {
+      throw new Error(
+        `Transaction submission failed: ${JSON.stringify(sendTxResponse)}`,
+      );
     }
 
-    private logToManualInterventionQueue(merchantId: string, reason: string) {
-        // In a real system, this would write to a database table or message queue
-        console.error(`[MANUAL INTERVENTION REQUIRED] Merchant ${merchantId} failed on-chain registration: ${reason}`);
+    // Wait for the transaction to be processed
+    let txResponse = await this.server.getTransaction(sendTxResponse.hash);
+
+    let retries = 0;
+    while (txResponse.status === "NOT_FOUND" && retries < 10) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      txResponse = await this.server.getTransaction(sendTxResponse.hash);
+      retries++;
     }
+
+    return true;
+  }
+
+  private async logToManualInterventionQueue(
+    merchantId: string,
+    reason: string,
+  ) {
+    console.error(
+      `[MANUAL INTERVENTION REQUIRED] Merchant ${merchantId} failed on-chain registration: ${reason}`,
+    );
+    try {
+      await prisma.manualIntervention.create({
+        data: {
+          merchantId,
+          issue_type: "onchain_registration_failed",
+          description: `On-chain registration failed after max retries. Reason: ${reason}`,
+        },
+      });
+    } catch (dbError) {
+      console.error(
+        `Failed to create manual intervention record for merchant ${merchantId}:`,
+        dbError,
+      );
+    }
+  }
 }
 
 export const merchantRegistryService = new MerchantRegistryService();

--- a/fluxapay_backend/tsconfig.json
+++ b/fluxapay_backend/tsconfig.json
@@ -10,8 +10,13 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types"],
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts", "src/**/__tests__/**"]
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "src/**/__tests__/**"
+  ]
 }


### PR DESCRIPTION


This PR addresses the requirement to ensure the merchant registration flow follows the correct order and handles on-chain registration failures appropriately, matching the Phase 1 specifications.

### Changes Made

- **Database Schema Updates (`schema.prisma`)**:
  - Added a new `ManualIntervention` model to track issues requiring human review.
  - Added a one-to-many relationship between `Merchant` and `ManualIntervention`.
  - Added enums `InterventionIssueType` and `InterventionStatus`.
- **Merchant Registry Service Updates (`merchantRegistry.service.ts`)**:
  - Updated the `register_merchant` method to throw an error if the maximum number of retries (3) is exceeded.
  - Implemented `logToManualInterventionQueue` to persist a record in the `ManualIntervention` table upon failure.
  - Imported `PrismaClient` to interact with the database.
- **Merchant Service Updates (`merchant.service.ts`)**:
  - Modified `signupMerchantService` to explicitly await the execution of `merchantRegistryService.register_merchant(merchant.id, business_name, settlement_currency)`.
  - This ensures the correct order of operations: DB Create -> Synchronous On-Chain Registration -> OTP Email.
  - Added a `try-catch` block around the registry call. If on-chain registration fails (which will also log it to the manual intervention table), the flow continues to send the OTP email, rather than halting the database creation or OTP verification. (This prevents merchants from being stuck in a limbo state without an OTP if the chain is temporarily down).

### Technical Requirements Met

- [x] Ensure on-chain registration runs after DB create but before welcome email (current order: DB -> registry async -> OTP email).
- [x] On registry failure after max retries: persist to `manual_intervention` table.



closes #146 