### PR TITLE
[192] [Frontend] Checkout: Prefer SSE stream over polling with fallback

### DIFF
--- a/fluxapay_frontend/src/app/api/payments/[payment_id]/paymentStatusStore.ts
+++ b/fluxapay_frontend/src/app/api/payments/[payment_id]/paymentStatusStore.ts
@@ -1,0 +1,5 @@
+export type PaymentStatusRecord = { status: string; createdAt: number };
+
+// Module-level singleton so polling + SSE share state in dev/mock mode.
+export const paymentStatusStore = new Map<string, PaymentStatusRecord>();
+

--- a/fluxapay_frontend/src/app/api/payments/[payment_id]/status/route.ts
+++ b/fluxapay_frontend/src/app/api/payments/[payment_id]/status/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-// In-memory store to simulate payment status changes
-// In production, this would be stored in a database
-const paymentStatusStore = new Map<string, { status: string; createdAt: number }>();
+import { paymentStatusStore } from '../paymentStatusStore';
 
 /**
  * Mock API endpoint to poll payment status

--- a/fluxapay_frontend/src/app/api/payments/[payment_id]/stream/route.ts
+++ b/fluxapay_frontend/src/app/api/payments/[payment_id]/stream/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from 'next/server';
 
-// Reuse the same in-memory store from the status route
-const paymentStatusStore = new Map<string, { status: string; createdAt: number }>();
+import { paymentStatusStore } from '../paymentStatusStore';
 
 /**
  * SSE endpoint for real-time payment status streaming.

--- a/fluxapay_frontend/src/features/dashboard/payments/PaymentsTable.tsx
+++ b/fluxapay_frontend/src/features/dashboard/payments/PaymentsTable.tsx
@@ -28,7 +28,7 @@ const SortIcon = memo(({ column, sortConfig }: SortIconProps) => {
 });
 SortIcon.displayName = "SortIcon";
 
-const getStatusBadge = memo(({ status }: { status: PaymentStatus }) => {
+const StatusBadge = memo(({ status }: { status: PaymentStatus }) => {
   switch (status) {
     case "confirmed":
       return <Badge variant="success">Confirmed</Badge>;
@@ -42,7 +42,7 @@ const getStatusBadge = memo(({ status }: { status: PaymentStatus }) => {
       return <Badge>{status}</Badge>;
   }
 });
-getStatusBadge.displayName = "StatusBadge";
+StatusBadge.displayName = "StatusBadge";
 
 interface PaymentRowProps {
   payment: Payment;
@@ -84,7 +84,7 @@ const PaymentRow = memo(({ payment, onRowClick }: PaymentRowProps) => {
         {formattedAmount}
       </td>
       <td className="px-4 py-4">
-        <getStatusBadge status={payment.status} />
+        <StatusBadge status={payment.status} />
       </td>
       <td className="px-4 py-4">
         <div className="flex flex-col">

--- a/fluxapay_frontend/src/features/webhooks/WebhooksTable.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhooksTable.tsx
@@ -28,7 +28,7 @@ const SortIcon = memo(({ column, sortConfig }: SortIconProps) => {
 });
 SortIcon.displayName = "SortIcon";
 
-const getStatusBadge = memo(({ status }: { status: WebhookStatus }) => {
+const StatusBadge = memo(({ status }: { status: WebhookStatus }) => {
     switch (status) {
         case "delivered":
             return <Badge variant="success">Delivered</Badge>;
@@ -40,7 +40,7 @@ const getStatusBadge = memo(({ status }: { status: WebhookStatus }) => {
             return <Badge>{status}</Badge>;
     }
 });
-getStatusBadge.displayName = "StatusBadge";
+StatusBadge.displayName = "StatusBadge";
 
 interface WebhookRowProps {
     webhook: WebhookEvent;
@@ -74,7 +74,7 @@ const WebhookRow = memo(({ webhook, onRowClick }: WebhookRowProps) => {
                 {webhook.eventType}
             </td>
             <td className="px-4 py-4">
-                <getStatusBadge status={webhook.status} />
+                <StatusBadge status={webhook.status} />
             </td>
             <td className="px-4 py-4 max-w-[200px] truncate text-muted-foreground" title={webhook.endpoint}>
                 {webhook.endpoint}


### PR DESCRIPTION
Closes #192

---

Closes 192

## Summary
- Prefer SSE via `/api/payments/:id/stream` with fallback to 3s polling.
- Ensure SSE + polling share a consistent mock status source.
- Fix status badge components that caused TypeScript build failures.

## Test plan
- `cd fluxapay_frontend && npm test`
- `cd fluxapay_frontend && npm run build`


