### PR TITLE
[193] [Frontend] Checkout: Show copy-to-clipboard address + memo/tag support

### DIFF
--- a/fluxapay_frontend/src/app/api/payments/[payment_id]/route.ts
+++ b/fluxapay_frontend/src/app/api/payments/[payment_id]/route.ts
@@ -20,6 +20,9 @@ export async function GET(
     amount: 100,
     currency: 'USDC',
     address: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH',
+    memoType: undefined as 'text' | 'id' | 'hash' | 'return' | undefined,
+    memo: undefined as string | undefined,
+    memoRequired: false,
     expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(), // 15 minutes from now
     status: 'pending' as const,
     successUrl: 'https://example.com/success',
@@ -49,6 +52,16 @@ export async function GET(
     return NextResponse.json({
       ...mockPayment,
       status: 'confirmed',
+    });
+  }
+
+  // Simulate memo/tag-required flows (some Stellar destinations require memo)
+  if (paymentId === 'memo-required' || paymentId === 'memo') {
+    return NextResponse.json({
+      ...mockPayment,
+      memoType: 'text',
+      memo: 'INV-10001',
+      memoRequired: true,
     });
   }
 

--- a/fluxapay_frontend/src/app/pay/[payment_id]/page.tsx
+++ b/fluxapay_frontend/src/app/pay/[payment_id]/page.tsx
@@ -154,9 +154,25 @@ export default function CheckoutPage() {
           <PaymentQRCode
             address={payment.address}
             amount={payment.amount}
+            memoType={payment.memoType}
+            memo={payment.memo}
             size={256}
           />
         </div>
+
+        {/* Memo required warning */}
+        {payment.memoRequired && (
+          <div
+            className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900"
+            role="alert"
+            aria-live="polite"
+          >
+            <p className="font-semibold">Memo required</p>
+            <p className="text-sm mt-1">
+              This payment destination requires a memo/tag. Please include the memo exactly as shown, or your payment may not be credited.
+            </p>
+          </div>
+        )}
 
         {/* Instructions */}
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 sm:p-6 mb-6">
@@ -174,7 +190,12 @@ export default function CheckoutPage() {
               <span aria-hidden="true" className="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">
                 2
               </span>
-              <span>Confirm the amount and payment address match</span>
+              <span>
+                Confirm the amount and payment address match
+                {payment.memoRequired && payment.memo && (
+                  <> (and include the required memo)</>
+                )}
+              </span>
             </li>
             <li className="flex items-start gap-3">
               <span aria-hidden="true" className="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">

--- a/fluxapay_frontend/src/components/checkout/PaymentQRCode.tsx
+++ b/fluxapay_frontend/src/components/checkout/PaymentQRCode.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import { QRCodeCanvas } from 'qrcode.react';
+import { Copy } from 'lucide-react';
+import toast from 'react-hot-toast';
 
 interface PaymentQRCodeProps {
   address: string;
   amount: number;
+  memoType?: 'text' | 'id' | 'hash' | 'return';
+  memo?: string;
   size?: number;
 }
 
@@ -12,9 +16,20 @@ interface PaymentQRCodeProps {
  * Component to display Stellar payment QR code
  * Formats the QR data as a Stellar URI for wallet compatibility
  */
-export function PaymentQRCode({ address, amount, size = 256 }: PaymentQRCodeProps) {
-  // Format as Stellar URI: stellar:address?amount=amount
-  const stellarUri = `stellar:${address}?amount=${amount}`;
+export function PaymentQRCode({ address, amount, memoType, memo, size = 256 }: PaymentQRCodeProps) {
+  const copyToClipboard = (text: string, label: string) => {
+    navigator.clipboard.writeText(text);
+    toast.success(`${label} copied to clipboard.`);
+  };
+
+  const query = new URLSearchParams({ amount: String(amount) });
+  if (memo && memoType) {
+    query.set('memo', memo);
+    query.set('memo_type', memoType);
+  }
+
+  // Keep existing scheme for compatibility with current wallets
+  const stellarUri = `stellar:${address}?${query.toString()}`;
 
   return (
     <div className="flex flex-col items-center space-y-4">
@@ -36,13 +51,49 @@ export function PaymentQRCode({ address, amount, size = 256 }: PaymentQRCodeProp
       {/* Payment Address */}
       <div className="w-full max-w-md">
         <p className="text-xs text-gray-500 text-center mb-1" id="payment-address-label">Payment Address</p>
-        <p
-          className="text-sm text-gray-700 text-center break-all font-mono bg-gray-50 px-3 py-2 rounded border"
-          aria-labelledby="payment-address-label"
-        >
-          {address}
-        </p>
+        <div className="flex items-center gap-2 bg-gray-50 px-3 py-2 rounded border">
+          <p
+            className="text-sm text-gray-700 break-all font-mono text-center flex-1"
+            aria-labelledby="payment-address-label"
+          >
+            {address}
+          </p>
+          <button
+            type="button"
+            onClick={() => copyToClipboard(address, 'Address')}
+            className="shrink-0 inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:text-blue-900"
+            aria-label="Copy payment address"
+          >
+            <Copy className="w-3 h-3" aria-hidden="true" />
+            Copy
+          </button>
+        </div>
       </div>
+
+      {memo && memoType && (
+        <div className="w-full max-w-md">
+          <p className="text-xs text-gray-500 text-center mb-1" id="payment-memo-label">
+            Memo ({memoType})
+          </p>
+          <div className="flex items-center gap-2 bg-gray-50 px-3 py-2 rounded border">
+            <p
+              className="text-sm text-gray-700 break-all font-mono text-center flex-1"
+              aria-labelledby="payment-memo-label"
+            >
+              {memo}
+            </p>
+            <button
+              type="button"
+              onClick={() => copyToClipboard(memo, 'Memo')}
+              className="shrink-0 inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:text-blue-900"
+              aria-label="Copy memo"
+            >
+              <Copy className="w-3 h-3" aria-hidden="true" />
+              Copy
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/fluxapay_frontend/src/features/dashboard/payments/PaymentsTable.tsx
+++ b/fluxapay_frontend/src/features/dashboard/payments/PaymentsTable.tsx
@@ -28,7 +28,7 @@ const SortIcon = memo(({ column, sortConfig }: SortIconProps) => {
 });
 SortIcon.displayName = "SortIcon";
 
-const getStatusBadge = memo(({ status }: { status: PaymentStatus }) => {
+const StatusBadge = memo(({ status }: { status: PaymentStatus }) => {
   switch (status) {
     case "confirmed":
       return <Badge variant="success">Confirmed</Badge>;
@@ -42,7 +42,7 @@ const getStatusBadge = memo(({ status }: { status: PaymentStatus }) => {
       return <Badge>{status}</Badge>;
   }
 });
-getStatusBadge.displayName = "StatusBadge";
+StatusBadge.displayName = "StatusBadge";
 
 interface PaymentRowProps {
   payment: Payment;
@@ -84,7 +84,7 @@ const PaymentRow = memo(({ payment, onRowClick }: PaymentRowProps) => {
         {formattedAmount}
       </td>
       <td className="px-4 py-4">
-        <getStatusBadge status={payment.status} />
+        <StatusBadge status={payment.status} />
       </td>
       <td className="px-4 py-4">
         <div className="flex flex-col">

--- a/fluxapay_frontend/src/features/webhooks/WebhooksTable.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhooksTable.tsx
@@ -28,7 +28,7 @@ const SortIcon = memo(({ column, sortConfig }: SortIconProps) => {
 });
 SortIcon.displayName = "SortIcon";
 
-const getStatusBadge = memo(({ status }: { status: WebhookStatus }) => {
+const StatusBadge = memo(({ status }: { status: WebhookStatus }) => {
     switch (status) {
         case "delivered":
             return <Badge variant="success">Delivered</Badge>;
@@ -40,7 +40,7 @@ const getStatusBadge = memo(({ status }: { status: WebhookStatus }) => {
             return <Badge>{status}</Badge>;
     }
 });
-getStatusBadge.displayName = "StatusBadge";
+StatusBadge.displayName = "StatusBadge";
 
 interface WebhookRowProps {
     webhook: WebhookEvent;
@@ -74,7 +74,7 @@ const WebhookRow = memo(({ webhook, onRowClick }: WebhookRowProps) => {
                 {webhook.eventType}
             </td>
             <td className="px-4 py-4">
-                <getStatusBadge status={webhook.status} />
+                <StatusBadge status={webhook.status} />
             </td>
             <td className="px-4 py-4 max-w-[200px] truncate text-muted-foreground" title={webhook.endpoint}>
                 {webhook.endpoint}

--- a/fluxapay_frontend/src/types/payment.ts
+++ b/fluxapay_frontend/src/types/payment.ts
@@ -3,6 +3,9 @@ export interface Payment {
   amount: number;
   currency: string;
   address: string; // Stellar payment address
+  memoType?: 'text' | 'id' | 'hash' | 'return';
+  memo?: string;
+  memoRequired?: boolean;
   expiresAt: Date;
   status: 'pending' | 'confirmed' | 'expired' | 'failed';
   successUrl?: string;


### PR DESCRIPTION
Closes #193

## Summary
- Add copy-to-clipboard actions for payment address and memo (when present).
- Extend payment type to support Stellar memo type/value + memo-required flag.
- Show a clear warning when a memo/tag is required.

## Test plan
- `cd fluxapay_frontend && npm test`
- `cd fluxapay_frontend && npm run build`


