### PR TITLE
[197] [Frontend] Dashboard: Webhooks page backed by backend webhook logs

### DIFF
--- a/fluxapay_frontend/src/app/dashboard/webhooks/page.tsx
+++ b/fluxapay_frontend/src/app/dashboard/webhooks/page.tsx
@@ -1,42 +1,81 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Header from "@/components/Header";
 import { WebhooksFilters } from "@/features/webhooks/WebhooksFilters";
 import { WebhooksTable } from "@/features/webhooks/WebhooksTable";
 import { WebhookDetails } from "@/features/webhooks/WebhookDetails";
 import { WebhookTest } from "@/features/webhooks/WebhookTest";
-import { mockWebhooks, WebhookEvent } from "@/features/webhooks/webhooks-mock";
 import { Button } from "@/components/Button";
 import { Send } from "lucide-react";
+import toast from "react-hot-toast";
+import { api } from "@/lib/api";
+import { WebhookEvent } from "@/features/webhooks/webhooks-mock";
 
 export default function WebhooksPage() {
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState("all");
     const [eventTypeFilter, setEventTypeFilter] = useState("all");
+    const [dateFrom, setDateFrom] = useState("");
+    const [dateTo, setDateTo] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [webhooks, setWebhooks] = useState<WebhookEvent[]>([]);
 
     const [selectedWebhook, setSelectedWebhook] = useState<WebhookEvent | null>(
         null
     );
     const [isTestModalOpen, setIsTestModalOpen] = useState(false);
 
-    // Filter webhooks
-    const filteredWebhooks = useMemo(() => {
-        return mockWebhooks.filter((webhook) => {
-            const matchSearch =
-                search === "" ||
-                webhook.id.toLowerCase().includes(search.toLowerCase()) ||
-                webhook.paymentId.toLowerCase().includes(search.toLowerCase());
+    useEffect(() => {
+        let cancelled = false;
+        async function load() {
+            setLoading(true);
+            try {
+                const date_from = dateFrom ? new Date(dateFrom).toISOString() : undefined;
+                const date_to = dateTo ? new Date(dateTo).toISOString() : undefined;
 
-            const matchStatus =
-                statusFilter === "all" || webhook.status === statusFilter;
+                const res = await api.webhooks.logs({
+                    search,
+                    status: statusFilter,
+                    event_type: eventTypeFilter,
+                    date_from,
+                    date_to,
+                    page: 1,
+                    limit: 50,
+                });
 
-            const matchEventType =
-                eventTypeFilter === "all" || webhook.eventType === eventTypeFilter;
+                if (cancelled) return;
 
-            return matchSearch && matchStatus && matchEventType;
-        });
-    }, [search, statusFilter, eventTypeFilter]);
+                const logs = res?.data?.logs ?? [];
+                const mapped: WebhookEvent[] = logs.map((log: any) => ({
+                    id: String(log.id),
+                    paymentId: String(log.payment_id ?? ""),
+                    eventType: String(log.event_type),
+                    status: log.status,
+                    endpoint: String(log.endpoint_url),
+                    attempts: Number(log.retry_count ?? 0) + 1,
+                    lastAttempt: String(log.updated_at ?? log.created_at),
+                    createdAt: String(log.created_at),
+                    payload: {},
+                    response: { status: Number(log.http_status ?? 0) },
+                    retryHistory: [],
+                }));
+
+                setWebhooks(mapped);
+            } catch (e) {
+                if (!cancelled) toast.error(e instanceof Error ? e.message : "Failed to load webhook logs");
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+
+        load();
+        return () => {
+            cancelled = true;
+        };
+    }, [search, statusFilter, eventTypeFilter, dateFrom, dateTo]);
+
+    const filteredWebhooks = useMemo(() => webhooks, [webhooks]);
 
     return (
         <div className="space-y-6 animate-in fade-in duration-500">
@@ -59,11 +98,14 @@ export default function WebhooksPage() {
                 onSearchChange={setSearch}
                 onStatusChange={setStatusFilter}
                 onEventTypeChange={setEventTypeFilter}
+                onDateFromChange={setDateFrom}
+                onDateToChange={setDateTo}
             />
 
             <WebhooksTable
                 webhooks={filteredWebhooks}
                 onRowClick={(webhook) => setSelectedWebhook(webhook)}
+                loading={loading}
             />
 
             <WebhookDetails

--- a/fluxapay_frontend/src/features/dashboard/payments/PaymentsTable.tsx
+++ b/fluxapay_frontend/src/features/dashboard/payments/PaymentsTable.tsx
@@ -28,7 +28,7 @@ const SortIcon = memo(({ column, sortConfig }: SortIconProps) => {
 });
 SortIcon.displayName = "SortIcon";
 
-const getStatusBadge = memo(({ status }: { status: PaymentStatus }) => {
+const StatusBadge = memo(({ status }: { status: PaymentStatus }) => {
   switch (status) {
     case "confirmed":
       return <Badge variant="success">Confirmed</Badge>;
@@ -42,7 +42,7 @@ const getStatusBadge = memo(({ status }: { status: PaymentStatus }) => {
       return <Badge>{status}</Badge>;
   }
 });
-getStatusBadge.displayName = "StatusBadge";
+StatusBadge.displayName = "StatusBadge";
 
 interface PaymentRowProps {
   payment: Payment;
@@ -84,7 +84,7 @@ const PaymentRow = memo(({ payment, onRowClick }: PaymentRowProps) => {
         {formattedAmount}
       </td>
       <td className="px-4 py-4">
-        <getStatusBadge status={payment.status} />
+        <StatusBadge status={payment.status} />
       </td>
       <td className="px-4 py-4">
         <div className="flex flex-col">

--- a/fluxapay_frontend/src/features/webhooks/WebhookDetails.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhookDetails.tsx
@@ -3,6 +3,9 @@ import { Button } from "@/components/Button";
 import { Badge } from "@/components/Badge";
 import { WebhookEvent, WebhookStatus } from "./webhooks-mock";
 import { Copy, RefreshCw } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { api } from "@/lib/api";
 
 interface WebhookDetailsProps {
     webhook: WebhookEvent | null;
@@ -15,10 +18,61 @@ export const WebhookDetails = ({
     isOpen,
     onClose,
 }: WebhookDetailsProps) => {
-    if (!webhook) return null;
+    const [loading, setLoading] = useState(false);
+    const [details, setDetails] = useState<WebhookEvent | null>(null);
+
+    const merged = useMemo(() => {
+        if (!webhook) return null;
+        return details ?? webhook;
+    }, [details, webhook]);
+
+    useEffect(() => {
+        let cancelled = false;
+        async function load() {
+            if (!isOpen || !webhook) return;
+            setLoading(true);
+            try {
+                const res = await api.webhooks.logDetails(webhook.id);
+                const d = res?.data;
+                if (!d || cancelled) return;
+
+                const retryAttempts = Array.isArray(d.retry_attempts) ? d.retry_attempts : [];
+
+                setDetails({
+                    id: String(d.id),
+                    paymentId: String(d.payment_id ?? ""),
+                    eventType: String(d.event_type),
+                    status: d.status,
+                    endpoint: String(d.endpoint_url),
+                    attempts: Number(d.retry_count ?? 0) + 1,
+                    lastAttempt: String(d.updated_at ?? d.created_at),
+                    createdAt: String(d.created_at),
+                    payload: (d.request_payload ?? {}) as Record<string, unknown>,
+                    response: {
+                        status: Number(d.http_status ?? 0),
+                        body: d.response_body,
+                    },
+                    retryHistory: retryAttempts.map((a: any) => ({
+                        timestamp: String(a.timestamp),
+                        status: d.status,
+                        responseCode: Number(a.http_status ?? 0),
+                    })),
+                });
+            } catch (e) {
+                if (!cancelled) toast.error(e instanceof Error ? e.message : "Failed to load webhook details");
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+        load();
+        return () => {
+            cancelled = true;
+        };
+    }, [webhook?.id, isOpen]);
 
     const handleCopy = (text: string) => {
         navigator.clipboard.writeText(text);
+        toast.success("Copied to clipboard.");
     };
 
     const getStatusBadge = (status: WebhookStatus) => {
@@ -34,6 +88,8 @@ export const WebhookDetails = ({
         }
     };
 
+    if (!webhook || !merged) return null;
+
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Webhook Details">
             <div className="space-y-6 max-h-[70vh] overflow-y-auto pr-2">
@@ -45,9 +101,9 @@ export const WebhookDetails = ({
                         </h4>
                         <div className="flex items-center gap-3">
                             <span className="font-mono text-sm bg-muted px-2 py-1 rounded">
-                                {webhook.eventType}
+                                {merged.eventType}
                             </span>
-                            {getStatusBadge(webhook.status)}
+                            {getStatusBadge(merged.status)}
                         </div>
                     </div>
                     <div className="text-right">
@@ -55,7 +111,7 @@ export const WebhookDetails = ({
                             Created At
                         </h4>
                         <span className="text-sm">
-                            {new Date(webhook.createdAt).toLocaleString()}
+                            {new Date(merged.createdAt).toLocaleString()}
                         </span>
                     </div>
                 </div>
@@ -65,14 +121,14 @@ export const WebhookDetails = ({
                     <h4 className="text-sm font-semibold text-muted-foreground flex justify-between items-center mb-2">
                         Endpoint
                         <button
-                            onClick={() => handleCopy(webhook.endpoint)}
+                            onClick={() => handleCopy(merged.endpoint)}
                             className="text-xs flex items-center gap-1 hover:text-primary transition-colors"
                         >
                             <Copy className="h-3 w-3" /> Copy
                         </button>
                     </h4>
                     <div className="bg-muted p-3 rounded-md font-mono text-sm break-all">
-                        {webhook.endpoint}
+                        {merged.endpoint}
                     </div>
                 </div>
 
@@ -82,7 +138,7 @@ export const WebhookDetails = ({
                         Request Payload
                         <button
                             onClick={() =>
-                                handleCopy(JSON.stringify(webhook.payload, null, 2))
+                                handleCopy(JSON.stringify(merged.payload, null, 2))
                             }
                             className="text-xs flex items-center gap-1 hover:text-primary transition-colors"
                         >
@@ -90,17 +146,17 @@ export const WebhookDetails = ({
                         </button>
                     </h4>
                     <pre className="bg-muted p-4 rounded-md font-mono text-xs overflow-x-auto text-foreground/90 border border-border/50">
-                        {JSON.stringify(webhook.payload, null, 2)}
+                        {JSON.stringify(merged.payload, null, 2)}
                     </pre>
                 </div>
 
                 {/* Response */}
                 <div>
                     <h4 className="text-sm font-semibold text-muted-foreground flex justify-between items-center mb-2">
-                        Response ({webhook.response.status})
+                        Response ({merged.response.status})
                         <button
                             onClick={() =>
-                                handleCopy(JSON.stringify(webhook.response, null, 2))
+                                handleCopy(JSON.stringify(merged.response, null, 2))
                             }
                             className="text-xs flex items-center gap-1 hover:text-primary transition-colors"
                         >
@@ -108,25 +164,25 @@ export const WebhookDetails = ({
                         </button>
                     </h4>
                     <pre className="bg-muted p-4 rounded-md font-mono text-xs overflow-x-auto text-foreground/90 border border-border/50">
-                        {JSON.stringify(webhook.response, null, 2)}
+                        {JSON.stringify(merged.response, null, 2)}
                     </pre>
                 </div>
 
                 {/* Retry History */}
-                {webhook.retryHistory && webhook.retryHistory.length > 0 && (
+                {merged.retryHistory && merged.retryHistory.length > 0 && (
                     <div>
                         <h4 className="text-sm font-semibold text-muted-foreground mb-3 border-b pb-2">
                             Retry History
                         </h4>
                         <div className="space-y-3">
-                            {webhook.retryHistory.map((retry, index) => (
+                            {merged.retryHistory.map((retry, index) => (
                                 <div
                                     key={index}
                                     className="flex items-center justify-between text-sm bg-muted/50 p-2 rounded-md"
                                 >
                                     <div className="flex items-center gap-3">
                                         <span className="text-muted-foreground">
-                                            Attempt {webhook.retryHistory.length - index}
+                                            Attempt {merged.retryHistory.length - index}
                                         </span>
                                         {getStatusBadge(retry.status)}
                                     </div>
@@ -149,7 +205,27 @@ export const WebhookDetails = ({
                     <Button variant="outline" onClick={onClose}>
                         Close
                     </Button>
-                    <Button variant="default" className="gap-2">
+                    <Button
+                        variant="default"
+                        className="gap-2"
+                        disabled={loading}
+                        onClick={async () => {
+                            try {
+                                setLoading(true);
+                                await api.webhooks.retry(webhook.id);
+                                toast.success("Retry initiated.");
+                                const res = await api.webhooks.logDetails(webhook.id);
+                                const d = res?.data;
+                                if (d) {
+                                    setDetails((prev) => prev ? { ...prev, status: d.status } : prev);
+                                }
+                            } catch (e) {
+                                toast.error(e instanceof Error ? e.message : "Retry failed");
+                            } finally {
+                                setLoading(false);
+                            }
+                        }}
+                    >
                         <RefreshCw className="h-4 w-4" />
                         Manual Retry
                     </Button>

--- a/fluxapay_frontend/src/features/webhooks/WebhookTest.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhookTest.tsx
@@ -4,6 +4,8 @@ import { Select } from "@/components/Select";
 import { Input } from "@/components/Input";
 import { useState } from "react";
 import { Send, CheckCircle2 } from "lucide-react";
+import toast from "react-hot-toast";
+import { api } from "@/lib/api";
 
 interface WebhookTestProps {
     isOpen: boolean;
@@ -11,7 +13,7 @@ interface WebhookTestProps {
 }
 
 export const WebhookTest = ({ isOpen, onClose }: WebhookTestProps) => {
-    const [eventType, setEventType] = useState("payment.success");
+    const [eventType, setEventType] = useState("payment_completed");
     const [endpoint, setEndpoint] = useState("");
     const [isTesting, setIsTesting] = useState(false);
     const [testResult, setTestResult] = useState<{
@@ -21,9 +23,9 @@ export const WebhookTest = ({ isOpen, onClose }: WebhookTestProps) => {
 
     const getMockPayload = (type: string) => {
         switch (type) {
-            case "payment.success":
+            case "payment_completed":
                 return {
-                    event: "payment.success",
+                    event_type: "payment_completed",
                     data: {
                         paymentId: "pay_test_123",
                         amount: 500,
@@ -31,9 +33,9 @@ export const WebhookTest = ({ isOpen, onClose }: WebhookTestProps) => {
                         status: "confirmed",
                     },
                 };
-            case "payment.failed":
+            case "payment_failed":
                 return {
-                    event: "payment.failed",
+                    event_type: "payment_failed",
                     data: {
                         paymentId: "pay_test_456",
                         amount: 100,
@@ -42,18 +44,19 @@ export const WebhookTest = ({ isOpen, onClose }: WebhookTestProps) => {
                         reason: "insufficient_funds",
                     },
                 };
-            case "payout.completed":
+            case "refund_completed":
                 return {
-                    event: "payout.completed",
+                    event_type: "refund_completed",
                     data: {
-                        payoutId: "po_test_789",
-                        amount: 10000,
+                        refundId: "rf_test_789",
+                        paymentId: "pay_test_123",
+                        amount: 50,
                         currency: "USDC",
                         status: "completed",
                     },
                 };
             default:
-                return { event: type, data: {} };
+                return { event_type: type, data: {} };
         }
     };
 
@@ -62,12 +65,21 @@ export const WebhookTest = ({ isOpen, onClose }: WebhookTestProps) => {
         setIsTesting(true);
         setTestResult(null);
 
-        // Simulate API call for testing the webhook
-        setTimeout(() => {
+        try {
+            const res = await api.webhooks.sendTest({
+                event_type: eventType,
+                endpoint_url: endpoint,
+            });
+            // Backend returns { message, data: { http_status, response_body, ... } }
+            const httpStatus = Number(res?.data?.http_status ?? 200);
+            setTestResult({ status: httpStatus, message: "OK" });
+            toast.success("Test webhook sent.");
+        } catch (e) {
+            toast.error(e instanceof Error ? e.message : "Failed to send test webhook");
+            setTestResult({ status: 0, message: "Failed" });
+        } finally {
             setIsTesting(false);
-            // Simulate success
-            setTestResult({ status: 200, message: "OK" });
-        }, 1500);
+        }
     };
 
     return (
@@ -88,9 +100,11 @@ export const WebhookTest = ({ isOpen, onClose }: WebhookTestProps) => {
                             value={eventType}
                             onChange={(e) => setEventType(e.target.value)}
                         >
-                            <option value="payment.success">payment.success</option>
-                            <option value="payment.failed">payment.failed</option>
-                            <option value="payout.completed">payout.completed</option>
+                            <option value="payment_completed">payment_completed</option>
+                            <option value="payment_failed">payment_failed</option>
+                            <option value="payment_pending">payment_pending</option>
+                            <option value="refund_completed">refund_completed</option>
+                            <option value="refund_failed">refund_failed</option>
                         </Select>
                     </div>
 

--- a/fluxapay_frontend/src/features/webhooks/WebhooksFilters.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhooksFilters.tsx
@@ -7,12 +7,16 @@ interface WebhooksFiltersProps {
     onSearchChange: (value: string) => void;
     onStatusChange: (value: string) => void;
     onEventTypeChange: (value: string) => void;
+    onDateFromChange: (value: string) => void;
+    onDateToChange: (value: string) => void;
 }
 
 export const WebhooksFilters = memo(({
     onSearchChange,
     onStatusChange,
     onEventTypeChange,
+    onDateFromChange,
+    onDateToChange,
 }: WebhooksFiltersProps) => {
     const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         onSearchChange(e.target.value);
@@ -25,6 +29,14 @@ export const WebhooksFilters = memo(({
     const handleEventTypeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
         onEventTypeChange(e.target.value);
     }, [onEventTypeChange]);
+
+    const handleDateFromChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        onDateFromChange(e.target.value);
+    }, [onDateFromChange]);
+
+    const handleDateToChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        onDateToChange(e.target.value);
+    }, [onDateToChange]);
     return (
         <div className="flex flex-col md:flex-row gap-4 mb-6">
             <div className="relative flex-1">
@@ -50,15 +62,23 @@ export const WebhooksFilters = memo(({
                     onChange={handleEventTypeChange}
                 >
                     <option value="all">All Event Types</option>
-                    <option value="payment.success">payment.success</option>
-                    <option value="payment.failed">payment.failed</option>
-                    <option value="payout.completed">payout.completed</option>
+                    <option value="payment_completed">payment_completed</option>
+                    <option value="payment_failed">payment_failed</option>
+                    <option value="payment_pending">payment_pending</option>
+                    <option value="refund_completed">refund_completed</option>
+                    <option value="refund_failed">refund_failed</option>
                 </Select>
-                {/* Simplified Date Range filter as a placeholder, could use a proper Date Picker component if available */}
                 <Input
                     type="date"
                     className="w-[150px]"
                     title="Start Date"
+                    onChange={handleDateFromChange}
+                />
+                <Input
+                    type="date"
+                    className="w-[150px]"
+                    title="End Date"
+                    onChange={handleDateToChange}
                 />
             </div>
         </div>

--- a/fluxapay_frontend/src/features/webhooks/WebhooksTable.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhooksTable.tsx
@@ -7,6 +7,7 @@ import { useState, useMemo, memo, useCallback } from "react";
 interface WebhooksTableProps {
     webhooks: WebhookEvent[];
     onRowClick: (webhook: WebhookEvent) => void;
+    loading?: boolean;
 }
 
 interface SortIconProps {
@@ -28,7 +29,7 @@ const SortIcon = memo(({ column, sortConfig }: SortIconProps) => {
 });
 SortIcon.displayName = "SortIcon";
 
-const getStatusBadge = memo(({ status }: { status: WebhookStatus }) => {
+const StatusBadge = memo(({ status }: { status: WebhookStatus }) => {
     switch (status) {
         case "delivered":
             return <Badge variant="success">Delivered</Badge>;
@@ -36,11 +37,13 @@ const getStatusBadge = memo(({ status }: { status: WebhookStatus }) => {
             return <Badge variant="warning">Pending</Badge>;
         case "failed":
             return <Badge variant="error">Failed</Badge>;
+        case "retrying":
+            return <Badge variant="warning">Retrying</Badge>;
         default:
             return <Badge>{status}</Badge>;
     }
 });
-getStatusBadge.displayName = "StatusBadge";
+StatusBadge.displayName = "StatusBadge";
 
 interface WebhookRowProps {
     webhook: WebhookEvent;
@@ -74,7 +77,7 @@ const WebhookRow = memo(({ webhook, onRowClick }: WebhookRowProps) => {
                 {webhook.eventType}
             </td>
             <td className="px-4 py-4">
-                <getStatusBadge status={webhook.status} />
+                <StatusBadge status={webhook.status} />
             </td>
             <td className="px-4 py-4 max-w-[200px] truncate text-muted-foreground" title={webhook.endpoint}>
                 {webhook.endpoint}
@@ -108,7 +111,7 @@ const WebhookRow = memo(({ webhook, onRowClick }: WebhookRowProps) => {
 });
 WebhookRow.displayName = "WebhookRow";
 
-export const WebhooksTable = ({ webhooks, onRowClick }: WebhooksTableProps) => {
+export const WebhooksTable = ({ webhooks, onRowClick, loading = false }: WebhooksTableProps) => {
     const [sortConfig, setSortConfig] = useState<{
         key: keyof WebhookEvent;
         direction: "asc" | "desc";
@@ -182,7 +185,7 @@ export const WebhooksTable = ({ webhooks, onRowClick }: WebhooksTableProps) => {
                             <EmptyState
                                 colSpan={7}
                                 className="px-4 py-12 text-muted-foreground"
-                                message="No webhooks found matching your filters."
+                                message={loading ? "Loading webhook logs..." : "No webhooks found matching your filters."}
                             />
                         ) : (
                             sortedWebhooks.map((webhook) => (

--- a/fluxapay_frontend/src/features/webhooks/webhooks-mock.ts
+++ b/fluxapay_frontend/src/features/webhooks/webhooks-mock.ts
@@ -1,4 +1,4 @@
-export type WebhookStatus = 'delivered' | 'pending' | 'failed';
+export type WebhookStatus = 'delivered' | 'pending' | 'failed' | 'retrying';
 
 export interface WebhookEvent {
   id: string;

--- a/fluxapay_frontend/src/lib/api.ts
+++ b/fluxapay_frontend/src/lib/api.ts
@@ -358,6 +358,41 @@ export const api = {
       }),
   },
 
+  // Webhooks (merchant-scoped webhook delivery logs)
+  webhooks: {
+    logs: (params?: {
+      event_type?: string;
+      status?: string;
+      date_from?: string;
+      date_to?: string;
+      search?: string;
+      page?: number;
+      limit?: number;
+    }) => {
+      const sp = new URLSearchParams();
+      if (params?.event_type && params.event_type !== "all") sp.set("event_type", params.event_type);
+      if (params?.status && params.status !== "all") sp.set("status", params.status);
+      if (params?.date_from) sp.set("date_from", params.date_from);
+      if (params?.date_to) sp.set("date_to", params.date_to);
+      if (params?.search) sp.set("search", params.search);
+      if (params?.page != null) sp.set("page", String(params.page));
+      if (params?.limit != null) sp.set("limit", String(params.limit));
+      return fetchWithAuth(`/api/webhooks/logs?${sp.toString()}`);
+    },
+    logDetails: (logId: string) => fetchWithAuth(`/api/webhooks/logs/${logId}`),
+    retry: (logId: string) =>
+      fetchWithAuth(`/api/webhooks/logs/${logId}/retry`, { method: "POST" }),
+    sendTest: (data: {
+      event_type: string;
+      endpoint_url: string;
+      payload_override?: Record<string, unknown>;
+    }) =>
+      fetchWithAuth("/api/webhooks/test", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+  },
+
   // Dashboard overview (metrics, charts, activity)
   dashboard: {
     overviewMetrics: (params?: { from?: string; to?: string }) => {


### PR DESCRIPTION
Closes #197

## Summary
- Replace mock webhook logs with backend-backed list view and filters.
- Fetch webhook log details in the modal and support manual retry.
- Send test webhook requests via backend endpoint.

## Test plan
- `cd fluxapay_frontend && npm test`
- `cd fluxapay_frontend && npm run build`


Made with [Cursor](https://cursor.com)