### PR TITLE
#210 [Backend] app.ts: Standardize API prefixes and remove duplicate mounts

### DIFF
--- a/fluxapay_backend/src/app.ts
+++ b/fluxapay_backend/src/app.ts
@@ -11,6 +11,11 @@ import paymentRoutes from "./routes/payment.route";
 import invoiceRoutes from "./routes/invoice.route";
 import refundRoutes from "./routes/refund.route";
 import reconciliationRoutes from "./routes/reconciliation.route";
+import sweepRoutes from "./routes/sweep.route";
+import keysRoutes from "./routes/keys.route";
+import settlementBatchRoutes from "./routes/settlementBatch.route";
+import dashboardRoutes from "./routes/dashboard.route";
+import auditRoutes from "./routes/audit.route";
 
 const app = express();
 const prisma = new PrismaClient();
@@ -21,14 +26,19 @@ app.use(express.json());
 // Swagger UI
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
 
-app.use("/api/merchants", merchantRoutes);
-app.use("/api/settlements", settlementRoutes);
-app.use("/api/merchants/kyc", kycRoutes);
-app.use("/api/webhooks", webhookRoutes);
-app.use("/api/payments", paymentRoutes);
-app.use("/api/invoices", invoiceRoutes);
-app.use("/api/refunds", refundRoutes);
-app.use("/api/admin/reconciliation", reconciliationRoutes);
+app.use("/api/v1/merchants", merchantRoutes);
+app.use("/api/v1/settlements", settlementRoutes);
+app.use("/api/v1/merchants/kyc", kycRoutes);
+app.use("/api/v1/webhooks", webhookRoutes);
+app.use("/api/v1/payments", paymentRoutes);
+app.use("/api/v1/invoices", invoiceRoutes);
+app.use("/api/v1/refunds", refundRoutes);
+app.use("/api/v1/keys", keysRoutes);
+app.use("/api/v1/dashboard", dashboardRoutes);
+app.use("/api/v1/admin/reconciliation", reconciliationRoutes);
+app.use("/api/v1/admin/settlement", settlementBatchRoutes);
+app.use("/api/v1/admin/sweep", sweepRoutes);
+app.use("/api/v1/admin", auditRoutes);
 
 // Basic health check
 app.get("/health", (req, res) => {

--- a/fluxapay_backend/src/docs/swagger.ts
+++ b/fluxapay_backend/src/docs/swagger.ts
@@ -10,7 +10,7 @@ const options: swaggerJsdoc.Options = {
         },
         servers: [
             {
-                url: 'http://localhost:3000',
+                url: 'http://localhost:3000/api/v1',
                 description: 'Local server',
             },
         ],

--- a/fluxapay_backend/src/routes/audit.route.ts
+++ b/fluxapay_backend/src/routes/audit.route.ts
@@ -11,7 +11,7 @@ router.use(adminAuth);
 
 /**
  * @swagger
- * /api/admin/audit-logs:
+ * /api/v1/admin/audit-logs:
  *   get:
  *     summary: Query audit logs with filters (Admin only)
  *     tags: [Admin - Audit]
@@ -37,7 +37,7 @@ router.get('/audit-logs', getAuditLogs);
 
 /**
  * @swagger
- * /api/admin/audit-logs/{id}:
+ * /api/v1/admin/audit-logs/{id}:
  *   get:
  *     summary: Get specific audit log by ID (Admin only)
  *     tags: [Admin - Audit]

--- a/fluxapay_backend/src/routes/dashboard.route.ts
+++ b/fluxapay_backend/src/routes/dashboard.route.ts
@@ -8,7 +8,7 @@ router.use(authenticateToken);
 
 /**
  * @swagger
- * /api/dashboard/overview/metrics:
+ * /api/v1/dashboard/overview/metrics:
  *   get:
  *     summary: Get dashboard summary metrics
  *     tags: [Dashboard]
@@ -59,7 +59,7 @@ router.get("/overview/metrics", dashboardController.overviewMetrics);
 
 /**
  * @swagger
- * /api/dashboard/overview/charts:
+ * /api/v1/dashboard/overview/charts:
  *   get:
  *     summary: Get dashboard analytics
  *     tags: [Dashboard]
@@ -117,7 +117,7 @@ router.get("/overview/charts", dashboardController.analytics);
 
 /**
  * @swagger
- * /api/dashboard/overview/activity:
+ * /api/v1/dashboard/overview/activity:
  *   get:
  *     summary: Get dashboard activity
  *     tags: [Dashboard]

--- a/fluxapay_backend/src/routes/invoice.route.ts
+++ b/fluxapay_backend/src/routes/invoice.route.ts
@@ -8,7 +8,7 @@ const router = Router();
 
 /**
  * @swagger
- * /api/invoices:
+ * /api/v1/invoices:
  *   post:
  *     summary: Create invoice and payment intent
  *     tags: [Invoices]

--- a/fluxapay_backend/src/routes/kyc.route.ts
+++ b/fluxapay_backend/src/routes/kyc.route.ts
@@ -143,7 +143,7 @@ const upload = multer({
 
 /**
  * @swagger
- * /api/merchants/kyc:
+ * /api/v1/merchants/kyc:
  *   post:
  *     summary: Submit KYC information
  *     description: Submit merchant KYC details for verification. This is the first step in the KYC process.
@@ -184,7 +184,7 @@ router.post(
 
 /**
  * @swagger
- * /api/merchants/kyc/documents:
+ * /api/v1/merchants/kyc/documents:
  *   post:
  *     summary: Upload KYC document
  *     description: Upload a document for KYC verification. Supported types are government_id, proof_of_business_registration, and proof_of_address.
@@ -235,7 +235,7 @@ router.post(
 
 /**
  * @swagger
- * /api/merchants/kyc/status:
+ * /api/v1/merchants/kyc/status:
  *   get:
  *     summary: Get KYC status
  *     description: Get the current KYC status and submitted information for the logged-in merchant
@@ -256,7 +256,7 @@ router.get("/status", authenticateToken, getKycStatus);
 
 /**
  * @swagger
- * /api/merchants/kyc/admin/submissions:
+ * /api/v1/merchants/kyc/admin/submissions:
  *   get:
  *     summary: Get all KYC submissions (Admin)
  *     description: Retrieve all KYC submissions with optional filtering by status. Admin only endpoint.
@@ -314,7 +314,7 @@ router.get("/admin/submissions", authenticateToken, getAllKycSubmissions);
 
 /**
  * @swagger
- * /api/merchants/kyc/admin/{merchantId}:
+ * /api/v1/merchants/kyc/admin/{merchantId}:
  *   get:
  *     summary: Get KYC details by merchant ID (Admin)
  *     description: Retrieve detailed KYC information for a specific merchant. Admin only endpoint.
@@ -340,7 +340,7 @@ router.get("/admin/:merchantId", authenticateToken, getKycDetailsByMerchantId);
 
 /**
  * @swagger
- * /api/merchants/kyc/admin/{merchantId}/status:
+ * /api/v1/merchants/kyc/admin/{merchantId}/status:
  *   patch:
  *     summary: Update KYC status (Admin)
  *     description: Approve or reject a merchant's KYC submission. Admin only endpoint.

--- a/fluxapay_backend/src/routes/merchant.route.ts
+++ b/fluxapay_backend/src/routes/merchant.route.ts
@@ -27,7 +27,7 @@ const router = Router();
 
 /**
  * @swagger
- * /api/merchants/signup:
+ * /api/v1/merchants/signup:
  *   post:
  *     summary: Register a new merchant
  *     tags: [Merchants]
@@ -67,7 +67,7 @@ router.post("/signup", idempotencyMiddleware, validate(merchantSchema.signupSche
 
 /**
  * @swagger
- * /api/merchants/login:
+ * /api/v1/merchants/login:
  *   post:
  *     summary: Login a merchant
  *     tags: [Merchants]
@@ -95,7 +95,7 @@ router.post("/login", validate(merchantSchema.loginSchema), loginMerchant);
 
 /**
  * @swagger
- * /api/merchants/verify-otp:
+ * /api/v1/merchants/verify-otp:
  *   post:
  *     summary: Verify OTP for merchant activation
  *     tags: [Merchants]
@@ -126,7 +126,7 @@ router.post("/login", validate(merchantSchema.loginSchema), loginMerchant);
 router.post("/verify-otp", idempotencyMiddleware, validate(merchantSchema.verifyOtpSchema), verifyOtp);
 /**
  * @swagger
- * /api/merchants/resend-otp:
+ * /api/v1/merchants/resend-otp:
  *   post:
  *     summary: Resend OTP
  *     tags: [Merchants]
@@ -155,7 +155,7 @@ router.post("/resend-otp", idempotencyMiddleware, validate(merchantSchema.resend
 
 /**
  * @swagger
- * /api/merchants/me:
+ * /api/v1/merchants/me:
  *   get:
  *     summary: Get the currently logged-in merchant
  *     tags: [Merchants]
@@ -182,7 +182,7 @@ router.get("/me", authenticateToken, getLoggedInMerchant);
 
 /**
  * @swagger
- * /api/merchants/me:
+ * /api/v1/merchants/me:
  *   patch:
  *     summary: Update merchant profile
  *     tags: [Merchants]
@@ -209,7 +209,7 @@ router.patch("/me", authenticateToken, updateMerchantProfile);
 
 /**
  * @swagger
- * /api/merchants/me/webhook:
+ * /api/v1/merchants/me/webhook:
  *   patch:
  *     summary: Update merchant webhook URL
  *     tags: [Merchants]
@@ -237,7 +237,7 @@ router.patch("/me/webhook", authenticateToken, updateMerchantWebhook);
 
 /**
  * @swagger
- * /api/merchants/keys/rotate-api-key:
+ * /api/v1/merchants/keys/rotate-api-key:
  *   post:
  *     summary: Rotate merchant API key
  *     tags: [Merchants]
@@ -260,7 +260,7 @@ router.post("/keys/rotate-api-key", authenticateToken, rotateApiKey);
 
 /**
  * @swagger
- * /api/merchants/keys/rotate-webhook-secret:
+ * /api/v1/merchants/keys/rotate-webhook-secret:
  *   post:
  *     summary: Rotate merchant webhook secret
  *     tags: [Merchants]
@@ -289,7 +289,7 @@ router.post(
 
 /**
  * @swagger
- * /api/merchants/admin/list:
+ * /api/v1/merchants/admin/list:
  *   get:
  *     summary: List all merchants (Admin only)
  *     tags: [Admin - Merchants]
@@ -305,7 +305,7 @@ router.get("/admin/list", adminAuth, adminListMerchants);
 
 /**
  * @swagger
- * /api/merchants/admin/{merchantId}:
+ * /api/v1/merchants/admin/{merchantId}:
  *   get:
  *     summary: Get merchant details by ID (Admin only)
  *     tags: [Admin - Merchants]
@@ -329,7 +329,7 @@ router.get("/admin/:merchantId", adminAuth, adminGetMerchant);
 
 /**
  * @swagger
- * /api/merchants/admin/{merchantId}/status:
+ * /api/v1/merchants/admin/{merchantId}/status:
  *   patch:
  *     summary: Update merchant account status (Admin only)
  *     tags: [Admin - Merchants]
@@ -363,7 +363,7 @@ router.get("/admin/:merchantId", adminAuth, adminGetMerchant);
 router.patch("/admin/:merchantId/status", adminAuth, adminUpdateMerchantStatus);
 /**
  * @swagger
- * /api/merchants/me/settlement-schedule:
+ * /api/v1/merchants/me/settlement-schedule:
  *   patch:
  *     summary: Update merchant settlement schedule
  *     tags: [Merchants]
@@ -404,7 +404,7 @@ router.patch(
 
 /**
  * @swagger
- * /api/merchants/me/bank-account:
+ * /api/v1/merchants/me/bank-account:
  *   post:
  *     summary: Add or update merchant bank account
  *     tags: [Merchants]

--- a/fluxapay_backend/src/routes/payment.route.ts
+++ b/fluxapay_backend/src/routes/payment.route.ts
@@ -7,7 +7,7 @@ const router = Router();
 
 /**
  * @swagger
- * /api/payments:
+ * /api/v1/payments:
  *   post:
  *     summary: Create payment intent
  *     tags: [Payments]

--- a/fluxapay_backend/src/routes/reconciliation.route.ts
+++ b/fluxapay_backend/src/routes/reconciliation.route.ts
@@ -20,7 +20,7 @@ router.use(authenticateToken);
 
 /**
  * @swagger
- * /api/admin/reconciliation/summary:
+ * /api/v1/admin/reconciliation/summary:
  *   get:
  *     summary: Get reconciliation period summary and detect discrepancies
  *     tags: [Reconciliation]
@@ -52,7 +52,7 @@ router.get("/summary", validateQuery(reconciliationSummaryQuerySchema), getRecon
 
 /**
  * @swagger
- * /api/admin/reconciliation/alerts:
+ * /api/v1/admin/reconciliation/alerts:
  *   get:
  *     summary: List discrepancy alerts for admin UI
  *     tags: [Reconciliation]
@@ -83,7 +83,7 @@ router.get("/alerts", validateQuery(discrepancyAlertsQuerySchema), listDiscrepan
 
 /**
  * @swagger
- * /api/admin/reconciliation/alerts/{alert_id}/resolve:
+ * /api/v1/admin/reconciliation/alerts/{alert_id}/resolve:
  *   patch:
  *     summary: Resolve or reopen discrepancy alert
  *     tags: [Reconciliation]
@@ -113,7 +113,7 @@ router.patch("/alerts/:alert_id/resolve", validate(resolveAlertSchema), resolveD
 
 /**
  * @swagger
- * /api/admin/reconciliation/thresholds:
+ * /api/v1/admin/reconciliation/thresholds:
  *   post:
  *     summary: Create or update discrepancy threshold configuration
  *     tags: [Reconciliation]

--- a/fluxapay_backend/src/routes/refund.route.ts
+++ b/fluxapay_backend/src/routes/refund.route.ts
@@ -16,7 +16,7 @@ const router = Router();
 
 /**
  * @swagger
- * /api/refunds:
+ * /api/v1/refunds:
  *   post:
  *     summary: Create a refund
  *     tags: [Refunds]
@@ -59,7 +59,7 @@ router.get("/", authenticateToken, validateQuery(listRefundsQuerySchema), listRe
 
 /**
  * @swagger
- * /api/refunds/{refund_id}/status:
+ * /api/v1/refunds/{refund_id}/status:
  *   patch:
  *     summary: Update refund status and emit webhook
  *     tags: [Refunds]

--- a/fluxapay_backend/src/routes/settlement.route.ts
+++ b/fluxapay_backend/src/routes/settlement.route.ts
@@ -16,7 +16,7 @@ router.use(authenticateToken);
 
 /**
  * @swagger
- * /api/settlements:
+ * /api/v1/settlements:
  *   get:
  *     summary: List settlements
  *     tags: [Settlements]
@@ -60,7 +60,7 @@ router.get("/", validate(settlementSchema.listSettlementsSchema), listSettlement
 
 /**
  * @swagger
- * /api/settlements/summary:
+ * /api/v1/settlements/summary:
  *   get:
  *     summary: Get settlement summary
  *     tags: [Settlements]
@@ -83,7 +83,7 @@ router.get("/summary", validate(settlementSchema.settlementSummarySchema), getSe
 
 /**
  * @swagger
- * /api/settlements/batch:
+ * /api/v1/settlements/batch:
  *   get:
  *     summary: Get settlement batch summary by scheduled date
  *     tags: [Settlements]
@@ -108,7 +108,7 @@ router.get("/batch", validate(settlementSchema.settlementBatchSchema), getSettle
 
 /**
  * @swagger
- * /api/settlements/{settlement_id}:
+ * /api/v1/settlements/{settlement_id}:
  *   get:
  *     summary: Get settlement details
  *     tags: [Settlements]
@@ -130,7 +130,7 @@ router.get("/:settlement_id", validate(settlementSchema.settlementDetailsSchema)
 
 /**
  * @swagger
- * /api/settlements/{settlement_id}/export:
+ * /api/v1/settlements/{settlement_id}/export:
  *   get:
  *     summary: Export settlement report
  *     tags: [Settlements]

--- a/fluxapay_backend/src/routes/settlementBatch.route.ts
+++ b/fluxapay_backend/src/routes/settlementBatch.route.ts
@@ -18,7 +18,7 @@ const router = Router();
 
 /**
  * @swagger
- * /api/admin/settlement/run:
+ * /api/v1/admin/settlement/run:
  *   post:
  *     summary: Manually trigger a settlement batch run
  *     tags: [Admin - Settlement]
@@ -72,7 +72,7 @@ router.post("/run", adminAuth, async (_req: Request, res: Response) => {
 
 /**
  * @swagger
- * /api/admin/settlement/status:
+ * /api/v1/admin/settlement/status:
  *   get:
  *     summary: Settlement system status
  *     tags: [Admin - Settlement]

--- a/fluxapay_backend/src/routes/sweep.route.ts
+++ b/fluxapay_backend/src/routes/sweep.route.ts
@@ -13,7 +13,7 @@ const router = Router();
 
 /**
  * @swagger
- * /api/admin/sweep/run:
+ * /api/v1/admin/sweep/run:
  *   post:
  *     summary: Manually trigger a sweep of paid payments
  *     tags: [Admin - Sweep]

--- a/fluxapay_backend/src/routes/webhook.route.ts
+++ b/fluxapay_backend/src/routes/webhook.route.ts
@@ -13,7 +13,7 @@ const router = Router();
 
 /**
  * @swagger
- * /api/webhooks/logs:
+ * /api/v1/webhooks/logs:
  *   get:
  *     summary: Get webhook logs list
  *     tags: [Webhooks]
@@ -102,7 +102,7 @@ router.get(
 
 /**
  * @swagger
- * /api/webhooks/logs/{log_id}:
+ * /api/v1/webhooks/logs/{log_id}:
  *   get:
  *     summary: Get webhook log details
  *     tags: [Webhooks]
@@ -155,7 +155,7 @@ router.get("/logs/:log_id", authenticateToken, getWebhookLogDetails);
 
 /**
  * @swagger
- * /api/webhooks/logs/{log_id}/retry:
+ * /api/v1/webhooks/logs/{log_id}/retry:
  *   post:
  *     summary: Retry a failed webhook
  *     tags: [Webhooks]
@@ -200,7 +200,7 @@ router.post("/logs/:log_id/retry", authenticateToken, retryWebhook);
 
 /**
  * @swagger
- * /api/webhooks/test:
+ * /api/v1/webhooks/test:
  *   post:
  *     summary: Send a test webhook
  *     tags: [Webhooks]


### PR DESCRIPTION
pr close #210 

- Update all route mounts in app.ts from /api/* to /api/v1/*
- Mount previously missing routes: keys, dashboard, sweep, settlementBatch, audit
- Update swagger server base URL to http://localhost:3000/api/v1
- Update all @swagger path annotations across 12 route files to /api/v1/*