### PR TITLE
feat: admin guard env check, payment scoping, sweep dry-run decisions , invoice reorder

### DIFF
--- a/fluxapay_backend/src/controllers/payment.controller.ts
+++ b/fluxapay_backend/src/controllers/payment.controller.ts
@@ -82,6 +82,9 @@ export const createPayment = async (req: Request, res: Response) => {
 export const getPayments = async (req: Request, res: Response) => {
     try {
         const merchantId = await validateUserId(req as AuthRequest);
+        if (!merchantId) {
+            return res.status(401).json({ error: "Unauthorized" });
+        }
 
         // 1. Destructure with explicit type casting immediately
         const query = req.query as Record<string, unknown>;
@@ -147,6 +150,15 @@ export const getPayments = async (req: Request, res: Response) => {
 
         res.json({ data, meta: { total, page, limit } });
     } catch (error: unknown) {
+        if (
+            error &&
+            typeof error === "object" &&
+            "status" in error &&
+            typeof (error as { status?: unknown }).status === "number"
+        ) {
+            const e = error as { status: number; message?: string };
+            return res.status(e.status).json({ error: e.message || "Unauthorized" });
+        }
         res.status(500).json({ error: "Internal Server Error" });
     }
 };

--- a/fluxapay_backend/src/services/sweep.service.ts
+++ b/fluxapay_backend/src/services/sweep.service.ts
@@ -28,6 +28,15 @@ export interface SweepOptions {
   enableAccountMerge?: boolean;
 }
 
+export interface SweepDecision {
+  paymentId: string;
+  action: "sweep" | "skip";
+  /** Populated for action=sweep: USDC amount that would be / was moved. */
+  amount?: string;
+  /** Populated for action=skip: human-readable reason the payment was skipped. */
+  reason?: string;
+}
+
 export interface SweepResult {
   sweepId: string;
   startedAt: Date;
@@ -37,6 +46,8 @@ export interface SweepResult {
   masterVaultPublicKey: string;
   txHashes: string[];
   skipped: Array<{ paymentId: string; reason: string }>;
+  /** Per-payment decisions; only populated when dryRun=true. */
+  decisions?: SweepDecision[];
 }
 
 function requiredEnv(name: string): string {
@@ -216,6 +227,7 @@ export class SweepService {
 
     const txHashes: string[] = [];
     const skipped: Array<{ paymentId: string; reason: string }> = [];
+    const decisions: SweepDecision[] = [];
     let total = 0;
     let addressesSwept = 0;
 
@@ -237,7 +249,9 @@ export class SweepService {
       try {
         const expected = Number(p.amount as any as Decimal);
         if (!Number.isFinite(expected) || expected <= 0) {
-          skipped.push({ paymentId: p.id, reason: "Invalid amount" });
+          const skipEntry = { paymentId: p.id, reason: "Invalid amount" };
+          skipped.push(skipEntry);
+          if (dryRun) decisions.push({ ...skipEntry, action: "skip" });
           continue;
         }
 
@@ -268,7 +282,9 @@ export class SweepService {
 
         // Ensure address matches DB (defense in depth)
         if (p.stellar_address && kp.publicKey !== p.stellar_address) {
-          skipped.push({ paymentId: p.id, reason: "Derived address mismatch" });
+          const skipEntry = { paymentId: p.id, reason: "Derived address mismatch" };
+          skipped.push(skipEntry);
+          if (dryRun) decisions.push({ ...skipEntry, action: "skip" });
           continue;
         }
 
@@ -282,11 +298,14 @@ export class SweepService {
 
         const accountUsdcAmount = Number(usdcBalanceEntry?.balance ?? "0");
         if (!Number.isFinite(accountUsdcAmount) || accountUsdcAmount <= 0) {
-          skipped.push({ paymentId: p.id, reason: "No USDC balance to sweep" });
+          const skipEntry = { paymentId: p.id, reason: "No USDC balance to sweep" };
+          skipped.push(skipEntry);
+          if (dryRun) decisions.push({ ...skipEntry, action: "skip" });
           continue;
         }
 
         if (dryRun) {
+          decisions.push({ paymentId: p.id, action: "sweep", amount: accountUsdcAmount.toFixed(7) });
           addressesSwept += 1;
           total += accountUsdcAmount;
           continue;
@@ -315,6 +334,7 @@ export class SweepService {
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         skipped.push({ paymentId: p.id, reason: msg });
+        if (dryRun) decisions.push({ paymentId: p.id, action: "skip", reason: msg });
       }
     }
 
@@ -349,6 +369,7 @@ export class SweepService {
       masterVaultPublicKey: this.vaultKeypair.publicKey(),
       txHashes,
       skipped,
+      ...(dryRun && { decisions }),
     };
   }
 }

--- a/fluxapay_frontend/src/app/admin/AdminGuard.tsx
+++ b/fluxapay_frontend/src/app/admin/AdminGuard.tsx
@@ -2,18 +2,27 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Loader2 } from 'lucide-react';
+import { Loader2, ShieldOff } from 'lucide-react';
+
+const ADMIN_ENABLED = process.env.NEXT_PUBLIC_ADMIN_ENABLED === 'true';
 
 /**
- * Client-side guard that redirects unauthenticated users away from /admin.
- * Checks for a JWT token in localStorage. Real role-based enforcement should
- * also be done server-side (middleware or server component) when auth is wired.
+ * Client-side guard that:
+ *  1. Blocks all admin pages when NEXT_PUBLIC_ADMIN_ENABLED is not 'true' — prevents
+ *     accidental exposure in environments where the admin secret is not configured.
+ *  2. Redirects unauthenticated users to /login.
  */
 export default function AdminGuard({ children }: { children: React.ReactNode }) {
     const router = useRouter();
     const [checked, setChecked] = useState(false);
 
     useEffect(() => {
+        if (!ADMIN_ENABLED) {
+            // Admin is not configured — stop here; don't touch localStorage or redirect.
+            setChecked(true);
+            return;
+        }
+
         const token = localStorage.getItem('token');
         const isAdmin = localStorage.getItem('isAdmin');
 
@@ -29,6 +38,22 @@ export default function AdminGuard({ children }: { children: React.ReactNode }) 
         return (
             <div className="min-h-screen bg-slate-50 flex items-center justify-center">
                 <Loader2 className="w-8 h-8 animate-spin text-slate-500" />
+            </div>
+        );
+    }
+
+    if (!ADMIN_ENABLED) {
+        return (
+            <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center gap-4 text-center px-4">
+                <ShieldOff className="w-12 h-12 text-slate-400" />
+                <h1 className="text-2xl font-semibold text-slate-700">Admin not enabled</h1>
+                <p className="text-slate-500 max-w-sm">
+                    The admin dashboard is not configured for this environment. Set{' '}
+                    <code className="rounded bg-slate-100 px-1 py-0.5 text-sm font-mono">
+                        NEXT_PUBLIC_ADMIN_ENABLED=true
+                    </code>{' '}
+                    to enable it.
+                </p>
             </div>
         );
     }

--- a/fluxapay_frontend/src/features/dashboard/invoices/InvoiceForm.tsx
+++ b/fluxapay_frontend/src/features/dashboard/invoices/InvoiceForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Invoice, LineItem } from "./invoices-mock";
 import { Button } from "@/components/Button";
+import { ChevronUp, ChevronDown } from "lucide-react";
 
 interface InvoiceFormProps {
   onSubmit: (invoice: Omit<Invoice, "id" | "invoice_number" | "payment_link" | "created_at">) => void;
@@ -10,17 +11,61 @@ interface InvoiceFormProps {
 }
 
 const CURRENCIES = ["USD", "EUR", "GBP", "NGN", "KES", "GHS"];
+const DRAFT_KEY = "invoice_form_draft";
 
 const emptyLineItem = (): LineItem => ({ description: "", quantity: 1, unit_price: 0 });
 
+interface DraftState {
+  customerName: string;
+  customerEmail: string;
+  currency: string;
+  dueDate: string;
+  notes: string;
+  lineItems: LineItem[];
+}
+
+function loadDraft(): DraftState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    return raw ? (JSON.parse(raw) as DraftState) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveDraft(state: DraftState) {
+  try {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(state));
+  } catch {
+    // storage quota exceeded — silently ignore
+  }
+}
+
+function clearDraft() {
+  try {
+    localStorage.removeItem(DRAFT_KEY);
+  } catch {
+    // ignore
+  }
+}
+
 export const InvoiceForm = ({ onSubmit, onCancel }: InvoiceFormProps) => {
-  const [customerName, setCustomerName] = useState("");
-  const [customerEmail, setCustomerEmail] = useState("");
-  const [currency, setCurrency] = useState("USD");
-  const [dueDate, setDueDate] = useState("");
-  const [notes, setNotes] = useState("");
-  const [lineItems, setLineItems] = useState<LineItem[]>([emptyLineItem()]);
+  const draft = loadDraft();
+
+  const [customerName, setCustomerName] = useState(draft?.customerName ?? "");
+  const [customerEmail, setCustomerEmail] = useState(draft?.customerEmail ?? "");
+  const [currency, setCurrency] = useState(draft?.currency ?? "USD");
+  const [dueDate, setDueDate] = useState(draft?.dueDate ?? "");
+  const [notes, setNotes] = useState(draft?.notes ?? "");
+  const [lineItems, setLineItems] = useState<LineItem[]>(draft?.lineItems ?? [emptyLineItem()]);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [hasDraft, setHasDraft] = useState(!!draft);
+
+  // Persist draft whenever form state changes
+  useEffect(() => {
+    saveDraft({ customerName, customerEmail, currency, dueDate, notes, lineItems });
+  }, [customerName, customerEmail, currency, dueDate, notes, lineItems]);
 
   const updateLineItem = (index: number, field: keyof LineItem, value: string | number) => {
     setLineItems((prev) =>
@@ -32,6 +77,16 @@ export const InvoiceForm = ({ onSubmit, onCancel }: InvoiceFormProps) => {
 
   const removeLineItem = (index: number) =>
     setLineItems((prev) => prev.filter((_, i) => i !== index));
+
+  const moveLineItem = (index: number, direction: "up" | "down") => {
+    setLineItems((prev) => {
+      const next = [...prev];
+      const target = direction === "up" ? index - 1 : index + 1;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
 
   const total = lineItems.reduce(
     (sum, item) => sum + Number(item.quantity) * Number(item.unit_price),
@@ -59,6 +114,7 @@ export const InvoiceForm = ({ onSubmit, onCancel }: InvoiceFormProps) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!validate()) return;
+    clearDraft();
     onSubmit({
       customer_name: customerName,
       customer_email: customerEmail,
@@ -75,6 +131,22 @@ export const InvoiceForm = ({ onSubmit, onCancel }: InvoiceFormProps) => {
     });
   };
 
+  const handleCancel = () => {
+    clearDraft();
+    onCancel();
+  };
+
+  const handleDiscardDraft = () => {
+    clearDraft();
+    setCustomerName("");
+    setCustomerEmail("");
+    setCurrency("USD");
+    setDueDate("");
+    setNotes("");
+    setLineItems([emptyLineItem()]);
+    setHasDraft(false);
+  };
+
   const inputClass =
     "h-10 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
   const labelClass = "mb-1 block text-sm font-medium";
@@ -82,6 +154,20 @@ export const InvoiceForm = ({ onSubmit, onCancel }: InvoiceFormProps) => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5 max-h-[70vh] overflow-y-auto pr-1">
+      {/* Draft restore banner */}
+      {hasDraft && (
+        <div className="flex items-center justify-between rounded-md bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-800">
+          <span>Draft restored from a previous session.</span>
+          <button
+            type="button"
+            onClick={handleDiscardDraft}
+            className="ml-4 text-xs underline hover:no-underline"
+          >
+            Discard draft
+          </button>
+        </div>
+      )}
+
       {/* Customer Info */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
@@ -146,7 +232,29 @@ export const InvoiceForm = ({ onSubmit, onCancel }: InvoiceFormProps) => {
         </div>
         <div className="space-y-3">
           {lineItems.map((item, index) => (
-            <div key={index} className="grid grid-cols-[1fr_80px_90px_32px] gap-2 items-start">
+            <div key={index} className="grid grid-cols-[20px_1fr_80px_90px_32px] gap-2 items-start">
+              {/* Reorder controls */}
+              <div className="flex flex-col gap-0.5 pt-1">
+                <button
+                  type="button"
+                  onClick={() => moveLineItem(index, "up")}
+                  disabled={index === 0}
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-20 transition-colors"
+                  title="Move up"
+                >
+                  <ChevronUp className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => moveLineItem(index, "down")}
+                  disabled={index === lineItems.length - 1}
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-20 transition-colors"
+                  title="Move down"
+                >
+                  <ChevronDown className="w-3.5 h-3.5" />
+                </button>
+              </div>
+
               <div>
                 <input
                   className={inputClass}
@@ -221,7 +329,7 @@ export const InvoiceForm = ({ onSubmit, onCancel }: InvoiceFormProps) => {
       </div>
 
       <div className="flex gap-3 pt-2">
-        <Button type="button" variant="secondary" className="flex-1" onClick={onCancel}>
+        <Button type="button" variant="secondary" className="flex-1" onClick={handleCancel}>
           Cancel
         </Button>
         <Button type="submit" className="flex-1">


### PR DESCRIPTION
## Summary

- **#430 — Admin route guard**: `AdminGuard` now checks `NEXT_PUBLIC_ADMIN_ENABLED === 'true'` before any auth logic. If not set, renders a "Admin not enabled" screen with a `ShieldOff` icon instead of granting access — prevents accidental exposure in environments without the admin secret configured.

- **#444 — Payment merchant scoping**: `getPayments` catch block now correctly propagates `{ status, message }` auth errors as 401 (was returning 500). Also added an explicit `!merchantId` guard after `validateUserId`. All list/get/export routes already require `authenticateApiKey` and scope queries by `merchantId`; `getPaymentById` already returns 404 for cross-merchant access.

- **#457 — Sweep dry-run reporting**: Added `SweepDecision` interface and `decisions?: SweepDecision[]` to `SweepResult`. In dry-run mode the service now records a per-payment entry (`action: 'sweep'` with amount, or `action: 'skip'` with reason) for every evaluated payment, returned alongside the existing `skipped` summary.

- **#434 — Invoice line-item editor UX**: Added ▲/▼ reorder buttons (using `ChevronUp`/`ChevronDown` from lucide-react) to each line-item row. Added local draft persistence via `localStorage` — form state is saved on every change, restored on re-open, with a banner offering to discard; draft is cleared on submit or cancel.

## Test plan
- [x] Set `NEXT_PUBLIC_ADMIN_ENABLED=` (unset) and verify `/admin` shows "Admin not enabled"
- [ ] Set `NEXT_PUBLIC_ADMIN_ENABLED=true` and verify normal auth flow works
- [ ] Call `GET /api/v1/payments` without API key — confirm 401 response
- [ ] Call `GET /api/v1/payments/:id` with another merchant's payment ID — confirm 404
- [ ] POST sweep with `dry_run: true` — confirm response includes `decisions` array with per-payment actions
- [ ] Open invoice create modal, fill items, close and reopen — confirm draft is restored
- [ ] Add 3+ line items and verify ▲/▼ buttons reorder correctly; first item has no ▲, last has no ▼

Closes #430 
Closes #444 
Closes #457 
Closes #434
