### PR TITLE
Dashboard list UX, webhooks, rate limits, and invoice list API 

### DIFF
--- a/fluxapay_backend/src/app.ts
+++ b/fluxapay_backend/src/app.ts
@@ -58,7 +58,8 @@ app.use((req, res, next) => {
   next();
 });
 
-// Global rate limit for all public API routes
+// Per-IP cap for all /api/v1 traffic (see PUBLIC_API_IP_RATE_MAX). Authenticated
+// routes also use merchantApiKeyRateLimit in route files.
 app.use("/api/v1", globalRateLimit());
 
 // Swagger UI

--- a/fluxapay_backend/src/controllers/invoice.controller.ts
+++ b/fluxapay_backend/src/controllers/invoice.controller.ts
@@ -23,11 +23,18 @@ export async function createInvoice(req: AuthRequest, res: Response) {
 export async function listInvoices(req: Request, res: Response) {
   try {
     const merchantId = await validateUserId(req as AuthRequest);
+    const q = req.query as {
+      page?: number;
+      limit?: number;
+      status?: "pending" | "paid" | "cancelled" | "overdue";
+      search?: string;
+    };
     const result = await listInvoicesService({
       merchantId,
-      page: Number(req.query.page) || 1,
-      limit: Number(req.query.limit) || 10,
-      status: req.query.status as "pending" | "paid" | "cancelled" | "overdue" | undefined,
+      page: q.page ?? 1,
+      limit: q.limit ?? 10,
+      status: q.status,
+      search: q.search,
     });
     res.status(200).json(result);
   } catch (err: any) {

--- a/fluxapay_backend/src/middleware/auth.middleware.ts
+++ b/fluxapay_backend/src/middleware/auth.middleware.ts
@@ -16,8 +16,11 @@ export function authenticateToken(
   if (!token) return res.status(401).json({ message: "Token missing" });
 
   try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
-    req.user = { id: payload?.id, email: payload?.email }; // attach payload to request for later use
+    const payload = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload & { id?: string };
+    req.user = { id: payload?.id, email: payload?.email };
+    if (payload?.id) {
+      req.merchantId = payload.id;
+    }
     next();
   } catch (_err) {
     return res.status(403).json({ message: "Invalid or expired token" });

--- a/fluxapay_backend/src/middleware/rateLimit.middleware.ts
+++ b/fluxapay_backend/src/middleware/rateLimit.middleware.ts
@@ -48,16 +48,24 @@ function checkLimit(
 }
 
 /**
- * Global rate limit for public API routes (keyed by IP).
+ * Global rate limit for public API traffic (keyed by IP).
  *
  * Default: 100 requests per 60 seconds per IP.
  * Configurable via env vars:
- *   GLOBAL_RATE_LIMIT_MAX        (default: 100)
- *   GLOBAL_RATE_LIMIT_WINDOW_MS  (default: 60000)
+ *   PUBLIC_API_IP_RATE_MAX          (alias, preferred)
+ *   GLOBAL_RATE_LIMIT_MAX           (legacy)
+ *   PUBLIC_API_IP_WINDOW_MS         (alias)
+ *   GLOBAL_RATE_LIMIT_WINDOW_MS     (legacy)
  */
 export function globalRateLimit(): RequestHandler {
-  const max = parseInt(process.env.GLOBAL_RATE_LIMIT_MAX || "100", 10);
-  const windowMs = parseInt(process.env.GLOBAL_RATE_LIMIT_WINDOW_MS || "60000", 10);
+  const max = parseInt(
+    process.env.PUBLIC_API_IP_RATE_MAX || process.env.GLOBAL_RATE_LIMIT_MAX || "100",
+    10,
+  );
+  const windowMs = parseInt(
+    process.env.PUBLIC_API_IP_WINDOW_MS || process.env.GLOBAL_RATE_LIMIT_WINDOW_MS || "60000",
+    10,
+  );
 
   return (req: Request, res: Response, next: NextFunction) => {
     const key = `global:${getIp(req)}`;
@@ -143,6 +151,51 @@ export function authRateLimit(): RequestHandler {
         error: {
           code: "RATE_LIMIT_EXCEEDED",
           message: "Too many authentication attempts. Please try again later.",
+          retry_after_seconds: retryAfterSeconds,
+        },
+      });
+    }
+
+    next();
+  };
+}
+
+/**
+ * Per-merchant / per-API-key limit for routes that run *after* `authenticateApiKey`
+ * or JWT that sets `merchantId` / `user.id`.
+ *
+ * Default: 200 requests per 60 seconds per merchant.
+ *   MERCHANT_API_KEY_RATE_MAX
+ *   MERCHANT_API_KEY_RATE_WINDOW_MS
+ */
+function getMerchantIdForApiKeyLimit(req: Request): string | null {
+  const a = req as AuthRequest;
+  if (a.merchantId) return a.merchantId;
+  if (a.user?.id) return a.user.id;
+  return null;
+}
+
+export function merchantApiKeyRateLimit(): RequestHandler {
+  const max = parseInt(process.env.MERCHANT_API_KEY_RATE_MAX || "200", 10);
+  const windowMs = parseInt(process.env.MERCHANT_API_KEY_RATE_WINDOW_MS || "60000", 10);
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const id = getMerchantIdForApiKeyLimit(req);
+    if (!id) {
+      return res.status(401).json({ message: "Authentication required" });
+    }
+    const key = `mapikey:${id}`;
+    const { allowed, retryAfterSeconds } = checkLimit(key, max, windowMs);
+
+    if (!allowed) {
+      res.setHeader("Retry-After", String(retryAfterSeconds));
+      res.setHeader("X-RateLimit-Limit", String(max));
+      res.setHeader("X-RateLimit-Remaining", "0");
+      return res.status(429).json({
+        success: false,
+        error: {
+          code: "RATE_LIMIT_EXCEEDED",
+          message: "API rate limit for this key exceeded. Please slow down.",
           retry_after_seconds: retryAfterSeconds,
         },
       });

--- a/fluxapay_backend/src/routes/customer.route.ts
+++ b/fluxapay_backend/src/routes/customer.route.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
+import { merchantApiKeyRateLimit } from "../middleware/rateLimit.middleware";
 import { validate, validateQuery } from "../middleware/validation.middleware";
 import {
   createCustomer,
@@ -58,10 +59,10 @@ const router = Router();
  *       200:
  *         description: Paginated customers
  */
-router.post("/", authenticateApiKey, validate(createCustomerSchema), createCustomer);
+router.post("/", authenticateApiKey, merchantApiKeyRateLimit(), validate(createCustomerSchema), createCustomer);
 router.get(
   "/",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validateQuery(listCustomersQuerySchema),
   listCustomers,
 );
@@ -126,19 +127,19 @@ router.get(
  */
 router.get(
   "/:id",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validate(customerIdParamsSchema),
   getCustomerById,
 );
 router.patch(
   "/:id",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validate(updateCustomerSchema),
   updateCustomer,
 );
 router.delete(
   "/:id",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validate(customerIdParamsSchema),
   deleteCustomer,
 );

--- a/fluxapay_backend/src/routes/dataExport.route.ts
+++ b/fluxapay_backend/src/routes/dataExport.route.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authenticateToken } from "../middleware/auth.middleware";
 import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
+import { merchantApiKeyRateLimit } from "../middleware/rateLimit.middleware";
 import { adminAuth } from "../middleware/adminAuth.middleware";
 import {
   requestExport,
@@ -26,7 +27,7 @@ const router = Router();
  *       401:
  *         description: Unauthorized
  */
-router.post("/", authenticateApiKey, requestExport);
+router.post("/", authenticateApiKey, merchantApiKeyRateLimit(), requestExport);
 /**
  * @swagger
  * /api/v1/merchants/export/{jobId}:
@@ -66,7 +67,7 @@ router.get("/:jobId", authenticateApiKey, getExportStatus);
  *       404:
  *         description: Job not found or not ready
  */
-router.get("/:jobId/download", authenticateApiKey, downloadExportHandler);
+router.get("/:jobId/download", authenticateApiKey, merchantApiKeyRateLimit(), downloadExportHandler);
 
 // ── Admin routes ──────────────────────────────────────────────────────────────
 /**

--- a/fluxapay_backend/src/routes/invoice.route.ts
+++ b/fluxapay_backend/src/routes/invoice.route.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
+import { merchantApiKeyRateLimit } from "../middleware/rateLimit.middleware";
 import { validate, validateQuery } from "../middleware/validation.middleware";
 import { createInvoice, listInvoices, exportInvoice } from "../controllers/invoice.controller";
 import { createInvoiceSchema, listInvoicesQuerySchema, exportInvoiceSchema } from "../schemas/invoice.schema";
@@ -44,12 +45,17 @@ const router = Router();
  *         schema:
  *           type: string
  *           enum: [pending, paid, cancelled, overdue]
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Search invoice number or customer email
  *     responses:
  *       200:
  *         description: Invoices retrieved
  */
-router.post("/", authenticateApiKey, validate(createInvoiceSchema), createInvoice);
-router.get("/", authenticateApiKey, validateQuery(listInvoicesQuerySchema), listInvoices);
+router.post("/", authenticateApiKey, merchantApiKeyRateLimit(), validate(createInvoiceSchema), createInvoice);
+router.get("/", authenticateApiKey, merchantApiKeyRateLimit(), validateQuery(listInvoicesQuerySchema), listInvoices);
 
 /**
  * @swagger
@@ -77,6 +83,6 @@ router.get("/", authenticateApiKey, validateQuery(listInvoicesQuerySchema), list
  *       404:
  *         description: Invoice not found
  */
-router.get("/:invoice_id/export", authenticateApiKey, validate(exportInvoiceSchema), exportInvoice);
+router.get("/:invoice_id/export", authenticateApiKey, merchantApiKeyRateLimit(), validate(exportInvoiceSchema), exportInvoice);
 
 export default router;

--- a/fluxapay_backend/src/routes/keys.route.ts
+++ b/fluxapay_backend/src/routes/keys.route.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
+import { merchantApiKeyRateLimit } from "../middleware/rateLimit.middleware";
 import { regenerateApiKey } from "../controllers/keys.controller";
 
 const router = Router();
@@ -25,6 +26,6 @@ const router = Router();
  *                 apiKey:
  *                   type: string
  */
-router.post("/regenerate", authenticateApiKey, regenerateApiKey);
+router.post("/regenerate", authenticateApiKey, merchantApiKeyRateLimit(), regenerateApiKey);
 
 export default router;

--- a/fluxapay_backend/src/routes/merchant.route.ts
+++ b/fluxapay_backend/src/routes/merchant.route.ts
@@ -22,7 +22,7 @@ import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
 import { idempotencyMiddleware } from "../middleware/idempotency.middleware";
 import { adminAuth } from "../middleware/adminAuth.middleware";
 import { updateSettlementScheduleSchema, bankAccountSchema } from "../schemas/merchant.schema";
-import { authRateLimit, merchantRateLimit } from "../middleware/rateLimit.middleware";
+import { authRateLimit, merchantApiKeyRateLimit, merchantRateLimit } from "../middleware/rateLimit.middleware";
 
 const router = Router();
 
@@ -180,7 +180,7 @@ router.post("/resend-otp", idempotencyMiddleware, authRateLimit(), validate(merc
  *       404:
  *         description: Merchant not found
  */
-router.get("/me", authenticateApiKey, getLoggedInMerchant);
+router.get("/me", authenticateApiKey, merchantApiKeyRateLimit(), getLoggedInMerchant);
 
 /**
  * @swagger
@@ -209,7 +209,7 @@ router.get("/me", authenticateApiKey, getLoggedInMerchant);
  */
 router.patch(
   "/me",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validate(merchantSchema.updateMerchantProfileSchema),
   updateMerchantProfile,
 );
@@ -239,7 +239,7 @@ router.patch(
  *       401:
  *         description: Unauthorized
  */
-router.patch("/me/webhook", authenticateApiKey, updateMerchantWebhook);
+router.patch("/me/webhook", authenticateApiKey, merchantApiKeyRateLimit(), updateMerchantWebhook);
 
 
 /**
@@ -263,7 +263,7 @@ router.patch("/me/webhook", authenticateApiKey, updateMerchantWebhook);
  *                 apiKey:
  *                   type: string
  */
-router.post("/keys/rotate-api-key", authenticateApiKey, merchantRateLimit(), rotateApiKey);
+router.post("/keys/rotate-api-key", authenticateApiKey, merchantApiKeyRateLimit(), merchantRateLimit(), rotateApiKey);
 
 /**
  * @swagger
@@ -288,7 +288,7 @@ router.post("/keys/rotate-api-key", authenticateApiKey, merchantRateLimit(), rot
  */
 router.post(
   "/keys/rotate-webhook-secret",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   merchantRateLimit(),
   rotateWebhookSecret,
 );
@@ -439,7 +439,7 @@ router.post("/admin/bulk-status", adminAuth, adminBulkUpdateMerchantStatus);
  */
 router.patch(
   "/me/settlement-schedule",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validate(updateSettlementScheduleSchema),
   updateSettlementSchedule,
 );
@@ -488,7 +488,7 @@ router.patch(
  */
 router.post(
   "/me/bank-account",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validate(bankAccountSchema),
   addBankAccount,
 );

--- a/fluxapay_backend/src/routes/merchantDeletion.route.ts
+++ b/fluxapay_backend/src/routes/merchantDeletion.route.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
+import { merchantApiKeyRateLimit } from "../middleware/rateLimit.middleware";
 import { authenticateToken } from "../middleware/auth.middleware";
 import { adminAuth } from "../middleware/adminAuth.middleware";
 import {
@@ -26,7 +27,11 @@ const router = Router();
  *       400:
  *         description: Invalid state
  */
-router.post("/me/deletion-request", authenticateApiKey, selfRequestDeletion);
+router.post(
+  "/me/deletion-request",
+  authenticateApiKey, merchantApiKeyRateLimit(),
+  selfRequestDeletion,
+);
 /**
  * @swagger
  * /api/v1/merchants/me/deletion-request:
@@ -41,7 +46,11 @@ router.post("/me/deletion-request", authenticateApiKey, selfRequestDeletion);
  *       404:
  *         description: No deletion request
  */
-router.get("/me/deletion-request", authenticateApiKey, selfGetDeletionRequest);
+router.get(
+  "/me/deletion-request",
+  authenticateApiKey, merchantApiKeyRateLimit(),
+  selfGetDeletionRequest,
+);
 
 // ── Admin ─────────────────────────────────────────────────────────────────────
 /**

--- a/fluxapay_backend/src/routes/payment.route.ts
+++ b/fluxapay_backend/src/routes/payment.route.ts
@@ -10,6 +10,7 @@ import {
 } from '../controllers/payment.controller';
 import { validatePayment } from '../validators/payment.validator';
 import { authenticateApiKey } from '../middleware/apiKeyAuth.middleware';
+import { merchantApiKeyRateLimit } from '../middleware/rateLimit.middleware';
 import { idempotencyMiddleware } from '../middleware/idempotency.middleware';
 import { simpleRateLimit } from "../middleware/simpleRateLimit.middleware";
 
@@ -196,7 +197,7 @@ router.get('/checkout/:id/stream', (_req, res) => {
 router.get('/checkout/:id/status', getPublicCheckoutPaymentStatus);
 router.get('/checkout/:id', getPublicCheckoutPayment);
 
-router.post('/', authenticateApiKey, idempotencyMiddleware, validatePayment, createPayment);
+router.post('/', authenticateApiKey, merchantApiKeyRateLimit(), idempotencyMiddleware, validatePayment, createPayment);
 
 /**
  * @swagger
@@ -232,7 +233,7 @@ router.post('/', authenticateApiKey, idempotencyMiddleware, validatePayment, cre
  *       200:
  *         description: Paginated list of payments
  */
-router.get('/', authenticateApiKey, getPayments);
+router.get('/', authenticateApiKey, merchantApiKeyRateLimit(), getPayments);
 
 /**
  * @swagger
@@ -246,7 +247,7 @@ router.get('/', authenticateApiKey, getPayments);
  *       200:
  *         description: CSV file download
  */
-router.get('/export', authenticateApiKey, getPayments);
+router.get('/export', authenticateApiKey, merchantApiKeyRateLimit(), getPayments);
 
 /**
  * @swagger
@@ -270,6 +271,6 @@ router.get('/export', authenticateApiKey, getPayments);
  *       404:
  *         description: Payment not found
  */
-router.get('/:id', authenticateApiKey, getPaymentById);
+router.get('/:id', authenticateApiKey, merchantApiKeyRateLimit(), getPaymentById);
 
 export default router;

--- a/fluxapay_backend/src/routes/refund.route.ts
+++ b/fluxapay_backend/src/routes/refund.route.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
+import { merchantApiKeyRateLimit } from "../middleware/rateLimit.middleware";
 import { validate, validateQuery } from "../middleware/validation.middleware";
 import { idempotencyMiddleware } from "../middleware/idempotency.middleware";
 import {
@@ -57,14 +58,14 @@ const router = Router();
  */
 router.post(
   "/",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   idempotencyMiddleware,
   validate(createRefundSchema),
   createRefund,
 );
 router.get(
   "/",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validateQuery(listRefundsQuerySchema),
   listRefunds,
 );
@@ -97,7 +98,7 @@ router.get(
  */
 router.patch(
   "/:refund_id/status",
-  authenticateApiKey,
+  authenticateApiKey, merchantApiKeyRateLimit(),
   validate(updateRefundStatusSchema),
   updateRefundStatus,
 );

--- a/fluxapay_backend/src/routes/settlement.route.ts
+++ b/fluxapay_backend/src/routes/settlement.route.ts
@@ -7,12 +7,14 @@ import {
     getSettlementBatch,
 } from "../controllers/settlement.controller";
 import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
+import { merchantApiKeyRateLimit } from "../middleware/rateLimit.middleware";
 import { validate } from "../middleware/validation.middleware";
 import * as settlementSchema from "../schemas/settlement.schema";
 
 const router = Router();
 
 router.use(authenticateApiKey);
+router.use(merchantApiKeyRateLimit());
 
 /**
  * @swagger

--- a/fluxapay_backend/src/routes/webhook.route.ts
+++ b/fluxapay_backend/src/routes/webhook.route.ts
@@ -8,6 +8,7 @@ import {
 import { validate, validateQuery } from "../middleware/validation.middleware";
 import * as webhookSchema from "../schemas/webhook.schema";
 import { authenticateToken } from "../middleware/auth.middleware";
+import { merchantApiKeyRateLimit } from "../middleware/rateLimit.middleware";
 
 const router = Router();
 
@@ -95,7 +96,7 @@ const router = Router();
  */
 router.get(
   "/logs",
-  authenticateToken,
+  authenticateToken, merchantApiKeyRateLimit(),
   validateQuery(webhookSchema.getWebhookLogsSchema),
   getWebhookLogs
 );
@@ -151,7 +152,7 @@ router.get(
  *       401:
  *         description: Unauthorized
  */
-router.get("/logs/:log_id", authenticateToken, getWebhookLogDetails);
+router.get("/logs/:log_id", authenticateToken, merchantApiKeyRateLimit(), getWebhookLogDetails);
 
 /**
  * @swagger
@@ -196,7 +197,11 @@ router.get("/logs/:log_id", authenticateToken, getWebhookLogDetails);
  *       401:
  *         description: Unauthorized
  */
-router.post("/logs/:log_id/retry", authenticateToken, retryWebhook);
+router.post(
+  "/logs/:log_id/retry",
+  authenticateToken, merchantApiKeyRateLimit(),
+  retryWebhook,
+);
 
 /**
  * @swagger
@@ -264,7 +269,7 @@ router.post("/logs/:log_id/retry", authenticateToken, retryWebhook);
  */
 router.post(
   "/test",
-  authenticateToken,
+  authenticateToken, merchantApiKeyRateLimit(),
   validate(webhookSchema.sendTestWebhookSchema),
   sendTestWebhook
 );

--- a/fluxapay_backend/src/schemas/invoice.schema.ts
+++ b/fluxapay_backend/src/schemas/invoice.schema.ts
@@ -12,6 +12,8 @@ export const listInvoicesQuerySchema = z.object({
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().positive().max(100).default(10),
   status: z.enum(["pending", "paid", "cancelled", "overdue"]).optional(),
+  /** Search invoice number or customer email (case-insensitive) */
+  search: z.string().trim().max(200).optional(),
 });
 
 export const exportInvoiceSchema = z.object({

--- a/fluxapay_backend/src/services/invoice.service.ts
+++ b/fluxapay_backend/src/services/invoice.service.ts
@@ -79,13 +79,21 @@ export async function listInvoicesService(params: {
   page: number;
   limit: number;
   status?: "pending" | "paid" | "cancelled" | "overdue";
+  search?: string;
 }) {
-  const { merchantId, page, limit, status } = params;
+  const { merchantId, page, limit, status, search } = params;
   const skip = (page - 1) * limit;
 
-  const where: Record<string, unknown> = { merchantId };
+  const where: Prisma.InvoiceWhereInput = { merchantId };
   if (status) {
     where.status = status;
+  }
+  const q = search?.trim();
+  if (q) {
+    where.OR = [
+      { invoice_number: { contains: q, mode: "insensitive" } },
+      { customer_email: { contains: q, mode: "insensitive" } },
+    ];
   }
 
   const [invoices, total] = await Promise.all([
@@ -98,16 +106,16 @@ export async function listInvoicesService(params: {
     prisma.invoice.count({ where }),
   ]);
 
+  const totalPages = Math.max(1, Math.ceil(total / limit) || 1);
+
   return {
     message: "Invoices retrieved",
-    data: {
-      invoices,
-      pagination: {
-        page,
-        limit,
-        total,
-        total_pages: Math.ceil(total / limit),
-      },
+    data: { invoices },
+    meta: {
+      page,
+      limit,
+      total,
+      total_pages: totalPages,
     },
   };
 }

--- a/fluxapay_frontend/src/app/[locale]/docs/authentication/page.tsx
+++ b/fluxapay_frontend/src/app/[locale]/docs/authentication/page.tsx
@@ -309,7 +309,7 @@ export default function LocalizedAuthenticationPage() {
         </section>
 
         {/* Webhook Signature Verification */}
-        <section>
+        <section id="webhook-verification">
           <h2 className="text-2xl font-bold text-slate-900 mb-4">Webhook Signature Verification</h2>
           <p className="text-slate-600 mb-4">
             All webhook requests from FluxaPay include a signature in the{" "}

--- a/fluxapay_frontend/src/app/dashboard/invoices/page.tsx
+++ b/fluxapay_frontend/src/app/dashboard/invoices/page.tsx
@@ -1,70 +1,109 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { Invoice } from "@/features/dashboard/invoices/invoices-mock";
+import { useState, useEffect, useCallback, useRef, Suspense } from "react";
+import { Invoice, InvoiceStatus } from "@/features/dashboard/invoices/invoices-mock";
 import { InvoicesTable } from "@/features/dashboard/invoices/InvoicesTable";
 import { InvoiceDetails } from "@/features/dashboard/invoices/InvoiceDetails";
 import { InvoiceForm } from "@/features/dashboard/invoices/InvoiceForm";
 import { Modal } from "@/components/Modal";
 import { Button } from "@/components/Button";
 import { Plus } from "lucide-react";
-import { Suspense } from "react";
 import { api, ApiError } from "@/lib/api";
 import toast from "react-hot-toast";
+import { DataTableCard, ListPageFilterBar, TablePaginationBar } from "@/components/data-table";
+import Input from "@/components/Input";
 
-const ALL_STATUSES = ["all", "unpaid", "pending", "paid", "overdue"];
+const PAGE_SIZE = 20;
+const ALL_STATUSES = ["all", "pending", "paid", "cancelled", "overdue"] as const;
+
+function mapBackendInvoice(row: Record<string, unknown>): Invoice {
+  const st = String(row.status ?? "");
+  const status: InvoiceStatus =
+    st === "cancelled"
+      ? "cancelled"
+      : st === "overdue"
+        ? "overdue"
+        : st === "paid"
+          ? "paid"
+          : st === "pending"
+            ? "pending"
+            : "unpaid";
+  return {
+    id: String(row.id),
+    invoice_number: String(row.invoice_number),
+    customer_name: "",
+    customer_email: String(row.customer_email),
+    line_items: [],
+    total_amount: Number(row.amount),
+    currency: String(row.currency),
+    due_date: row.due_date
+      ? new Date(String(row.due_date)).toISOString()
+      : new Date(0).toISOString(),
+    status,
+    payment_link: String(row.payment_link ?? ""),
+    created_at: new Date(String(row.created_at)).toISOString(),
+  };
+}
 
 function InvoicesContent() {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [statusFilter, setStatusFilter] = useState("all");
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
-  const [, setHasMore] = useState(true);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(() => setDebouncedSearch(search), 400);
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  }, [search]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter, debouncedSearch]);
 
   const fetchInvoices = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
     try {
-      setIsLoading(true);
-      const response = await api.invoices.list({
+      const { invoices: rows, meta } = await api.invoices.list({
         page,
-        limit: 20,
+        limit: PAGE_SIZE,
         status: statusFilter !== "all" ? statusFilter : undefined,
+        search: debouncedSearch.trim() || undefined,
       });
-      
-      if (page === 1) {
-        setInvoices(response.invoices || []);
-      } else {
-        setInvoices((prev) => [...prev, ...(response.invoices || [])]);
-      }
-      setHasMore(response.hasMore || false);
+      setTotal(meta.total);
+      setInvoices(
+        (rows as Record<string, unknown>[]).map((r) => mapBackendInvoice(r)),
+      );
     } catch (err) {
       if (err instanceof ApiError) {
+        setLoadError(err.message);
         toast.error(err.message);
       } else {
-        toast.error("Failed to load invoices");
+        const msg = "Failed to load invoices";
+        setLoadError(msg);
+        toast.error(msg);
       }
     } finally {
       setIsLoading(false);
     }
-  }, [page, statusFilter]);
+  }, [page, statusFilter, debouncedSearch]);
 
   useEffect(() => {
     fetchInvoices();
   }, [fetchInvoices]);
 
-  const filteredInvoices = invoices.filter((invoice) => {
-    if (!search) return true;
-    return (
-      invoice.invoice_number?.toLowerCase().includes(search.toLowerCase()) ||
-      invoice.customer_name?.toLowerCase().includes(search.toLowerCase()) ||
-      invoice.customer_email?.toLowerCase().includes(search.toLowerCase())
-    );
-  });
-
   const handleCreateInvoice = async (
-    data: Omit<Invoice, "id" | "invoice_number" | "payment_link" | "created_at">
+    data: Omit<Invoice, "id" | "invoice_number" | "payment_link" | "created_at">,
   ) => {
     try {
       await api.invoices.create({
@@ -75,11 +114,9 @@ function InvoicesContent() {
         due_date: data.due_date,
         notes: data.notes,
       });
-      
+
       toast.success("Invoice created successfully!");
       setShowCreateModal(false);
-      
-      // Refresh the list
       setPage(1);
       fetchInvoices();
     } catch (err) {
@@ -93,7 +130,6 @@ function InvoicesContent() {
 
   return (
     <div className="space-y-6">
-      {/* Page Header */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
           <h2 className="text-2xl font-bold tracking-tight">Invoices</h2>
@@ -107,41 +143,48 @@ function InvoicesContent() {
         </Button>
       </div>
 
-      {/* Filters */}
-      <div className="bg-card rounded-2xl border p-6 shadow-sm space-y-4">
-        <div className="flex flex-col sm:flex-row gap-3">
-          <input
-            type="text"
-            placeholder="Search by invoice #, customer name or email…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="h-10 flex-1 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      <DataTableCard
+        toolbar={
+          <ListPageFilterBar>
+            <div className="relative flex-1 min-w-[200px]">
+              <Input
+                placeholder="Search by invoice # or email…"
+                className="w-full"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              {ALL_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {s === "all" ? "All statuses" : s.charAt(0).toUpperCase() + s.slice(1)}
+                </option>
+              ))}
+            </select>
+          </ListPageFilterBar>
+        }
+        footer={
+          <TablePaginationBar
+            page={page}
+            pageSize={PAGE_SIZE}
+            total={total}
+            loading={isLoading}
+            onPageChange={setPage}
           />
-          <select
-            value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value)}
-            className="h-10 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          >
-            {ALL_STATUSES.map((s) => (
-              <option key={s} value={s}>
-                {s === "all" ? "All Statuses" : s.charAt(0).toUpperCase() + s.slice(1)}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {/* Table */}
+        }
+      >
         <InvoicesTable
-          invoices={filteredInvoices}
+          isLoading={isLoading}
+          error={loadError}
+          invoices={invoices}
           onRowClick={(invoice) => setSelectedInvoice(invoice)}
         />
+      </DataTableCard>
 
-        <div className="mt-4 text-sm text-muted-foreground">
-          Showing {filteredInvoices.length} of {invoices.length} invoices
-        </div>
-      </div>
-
-      {/* Detail Modal */}
       <Modal
         isOpen={!!selectedInvoice}
         onClose={() => setSelectedInvoice(null)}
@@ -150,7 +193,6 @@ function InvoicesContent() {
         {selectedInvoice && <InvoiceDetails invoice={selectedInvoice} />}
       </Modal>
 
-      {/* Create Modal */}
       <Modal
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}

--- a/fluxapay_frontend/src/app/dashboard/payments/page.tsx
+++ b/fluxapay_frontend/src/app/dashboard/payments/page.tsx
@@ -18,6 +18,7 @@ import { Suspense } from "react";
 import toast from "react-hot-toast";
 import { api } from "@/lib/api";
 import { QRCodeCanvas } from "qrcode.react";
+import { DataTableCard, TablePaginationBar } from "@/components/data-table";
 
 const PAGE_SIZE = 20;
 
@@ -97,6 +98,7 @@ function PaymentsContent() {
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
@@ -130,6 +132,7 @@ function PaymentsContent() {
 
   const fetchPayments = useCallback(async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const result = (await api.payments.list({
         page,
@@ -141,7 +144,9 @@ function PaymentsContent() {
       setPayments(result.data.map(mapBackendPayment));
       setTotal(result.meta.total);
     } catch {
-      toast.error("Failed to load payments.");
+      const msg = "Failed to load payments.";
+      setLoadError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }
@@ -273,8 +278,6 @@ function PaymentsContent() {
     }
   };
 
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-
   return (
     <div className="space-y-6">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
@@ -299,91 +302,71 @@ function PaymentsContent() {
         </div>
       </div>
 
-      <div className="bg-card rounded-2xl border p-6 shadow-sm">
-        {recentLinks.length > 0 && (
-          <div className="mb-6 space-y-3">
-            <div>
-              <h3 className="text-sm font-semibold">Recent payment links</h3>
-              <p className="text-xs text-muted-foreground">Links you&apos;ve generated in this session.</p>
-            </div>
-            <div className="space-y-2">
-              {recentLinks.map((link) => (
-                <div
-                  key={link.id}
-                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2"
-                >
-                  <div className="min-w-0">
-                    <p className="text-xs font-medium break-all">{link.url}</p>
-                    <p className="mt-1 text-[11px] text-muted-foreground">
-                      {link.amount} {link.currency}
-                      {link.description ? ` • ${link.description}` : ""} •{" "}
-                      {new Date(link.createdAt).toLocaleString()}
-                    </p>
-                  </div>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="shrink-0 mt-1 sm:mt-0"
-                    onClick={async () => {
-                      await navigator.clipboard.writeText(link.url);
-                      toast.success("Payment link copied to clipboard.");
-                    }}
-                  >
-                    Copy
-                  </Button>
+      {recentLinks.length > 0 && (
+        <div className="bg-card rounded-2xl border p-6 shadow-sm space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold">Recent payment links</h3>
+            <p className="text-xs text-muted-foreground">Links you&apos;ve generated in this session.</p>
+          </div>
+          <div className="space-y-2">
+            {recentLinks.map((link) => (
+              <div
+                key={link.id}
+                className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="text-xs font-medium break-all">{link.url}</p>
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    {link.amount} {link.currency}
+                    {link.description ? ` • ${link.description}` : ""} •{" "}
+                    {new Date(link.createdAt).toLocaleString()}
+                  </p>
                 </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        <PaymentsFilters
-          searchValue={search}
-          statusValue={statusFilter}
-          currencyValue={currencyFilter}
-          onSearchChange={handleSearchChange}
-          onStatusChange={(v) => setStatusFilter(v)}
-          onCurrencyChange={(v) => setCurrencyFilter(v)}
-        />
-
-        {loading ? (
-          <div className="flex items-center justify-center py-16">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-          </div>
-        ) : (
-          <PaymentsTable
-            payments={payments}
-            onRowClick={(payment) => setSelectedPaymentId(payment.id)}
-          />
-        )}
-
-        <div className="mt-6 flex items-center justify-between text-sm text-muted-foreground">
-          <p>
-            Showing {payments.length} of {total} payments
-          </p>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={page <= 1 || loading}
-              onClick={() => setPage((p) => p - 1)}
-            >
-              Previous
-            </Button>
-            <span className="text-xs">
-              {page} / {totalPages}
-            </span>
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={page >= totalPages || loading}
-              onClick={() => setPage((p) => p + 1)}
-            >
-              Next
-            </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="shrink-0 mt-1 sm:mt-0"
+                  onClick={async () => {
+                    await navigator.clipboard.writeText(link.url);
+                    toast.success("Payment link copied to clipboard.");
+                  }}
+                >
+                  Copy
+                </Button>
+              </div>
+            ))}
           </div>
         </div>
-      </div>
+      )}
+
+      <DataTableCard
+        toolbar={
+          <PaymentsFilters
+            searchValue={search}
+            statusValue={statusFilter}
+            currencyValue={currencyFilter}
+            onSearchChange={handleSearchChange}
+            onStatusChange={(v) => setStatusFilter(v)}
+            onCurrencyChange={(v) => setCurrencyFilter(v)}
+          />
+        }
+        footer={
+          <TablePaginationBar
+            page={page}
+            pageSize={PAGE_SIZE}
+            total={total}
+            loading={loading}
+            onPageChange={setPage}
+          />
+        }
+      >
+        <PaymentsTable
+          isLoading={loading}
+          error={loadError}
+          payments={payments}
+          onRowClick={(payment) => setSelectedPaymentId(payment.id)}
+        />
+      </DataTableCard>
 
       <Modal
         isOpen={!!selectedPayment}

--- a/fluxapay_frontend/src/app/dashboard/webhooks/page.tsx
+++ b/fluxapay_frontend/src/app/dashboard/webhooks/page.tsx
@@ -11,6 +11,7 @@ import { Send } from "lucide-react";
 import { toastApiError } from "@/lib/toastApiError";
 import { api } from "@/lib/api";
 import { WebhookEvent } from "@/features/webhooks/webhooks-mock";
+import { DataTableCard, TablePaginationBar } from "@/components/data-table";
 
 export default function WebhooksPage() {
     const [search, setSearch] = useState("");
@@ -19,7 +20,11 @@ export default function WebhooksPage() {
     const [dateFrom, setDateFrom] = useState("");
     const [dateTo, setDateTo] = useState("");
     const [loading, setLoading] = useState(false);
+    const [loadError, setLoadError] = useState<string | null>(null);
     const [webhooks, setWebhooks] = useState<WebhookEvent[]>([]);
+    const [page, setPage] = useState(1);
+    const [total, setTotal] = useState(0);
+    const pageSize = 50;
 
     const [selectedWebhook, setSelectedWebhook] = useState<WebhookEvent | null>(
         null
@@ -30,6 +35,7 @@ export default function WebhooksPage() {
         let cancelled = false;
         async function load() {
             setLoading(true);
+            setLoadError(null);
             try {
                 const date_from = dateFrom ? new Date(dateFrom).toISOString() : undefined;
                 const date_to = dateTo ? new Date(dateTo).toISOString() : undefined;
@@ -40,13 +46,15 @@ export default function WebhooksPage() {
                     event_type: eventTypeFilter,
                     date_from,
                     date_to,
-                    page: 1,
-                    limit: 50,
+                    page,
+                    limit: pageSize,
                 });
 
                 if (cancelled) return;
 
                 const logs = res?.data?.logs ?? [];
+                const pag = res?.data?.pagination as { total?: number } | undefined;
+                setTotal(typeof pag?.total === "number" ? pag.total : logs.length);
                 const mapped: WebhookEvent[] = logs.map(
                   (log: Record<string, unknown>) => ({
                     id: String(log.id),
@@ -65,7 +73,10 @@ export default function WebhooksPage() {
 
                 setWebhooks(mapped);
             } catch (e) {
-                if (!cancelled) toastApiError(e);
+                if (!cancelled) {
+                    setLoadError("Failed to load webhook logs.");
+                    toastApiError(e);
+                }
             } finally {
                 if (!cancelled) setLoading(false);
             }
@@ -75,6 +86,10 @@ export default function WebhooksPage() {
         return () => {
             cancelled = true;
         };
+    }, [search, statusFilter, eventTypeFilter, dateFrom, dateTo, page]);
+
+    useEffect(() => {
+        setPage(1);
     }, [search, statusFilter, eventTypeFilter, dateFrom, dateTo]);
 
     const filteredWebhooks = useMemo(() => webhooks, [webhooks]);
@@ -96,19 +111,33 @@ export default function WebhooksPage() {
                 </Button>
             </div>
 
-            <WebhooksFilters
-                onSearchChange={setSearch}
-                onStatusChange={setStatusFilter}
-                onEventTypeChange={setEventTypeFilter}
-                onDateFromChange={setDateFrom}
-                onDateToChange={setDateTo}
-            />
-
-            <WebhooksTable
-                webhooks={filteredWebhooks}
-                onRowClick={(webhook) => setSelectedWebhook(webhook)}
-                loading={loading}
-            />
+            <DataTableCard
+                toolbar={
+                    <WebhooksFilters
+                        onSearchChange={setSearch}
+                        onStatusChange={setStatusFilter}
+                        onEventTypeChange={setEventTypeFilter}
+                        onDateFromChange={setDateFrom}
+                        onDateToChange={setDateTo}
+                    />
+                }
+                footer={
+                    <TablePaginationBar
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        loading={loading}
+                        onPageChange={setPage}
+                    />
+                }
+            >
+                <WebhooksTable
+                    webhooks={filteredWebhooks}
+                    onRowClick={(webhook) => setSelectedWebhook(webhook)}
+                    loading={loading}
+                    error={loadError}
+                />
+            </DataTableCard>
 
             <WebhookDetails
                 webhook={selectedWebhook}

--- a/fluxapay_frontend/src/components/data-table/DataTableBodyState.tsx
+++ b/fluxapay_frontend/src/components/data-table/DataTableBodyState.tsx
@@ -1,0 +1,66 @@
+import { type ReactNode } from "react";
+import EmptyState from "@/components/EmptyState";
+
+type State = "ready" | "loading" | "error" | "empty";
+
+type Props = {
+  colSpan: number;
+  state: State;
+  errorMessage?: string;
+  emptyMessage?: string;
+  loadingMessage?: string;
+  children: ReactNode;
+};
+
+/**
+ * Single place for loading / error / empty row behavior inside a &lt;tbody&gt;.
+ */
+export function DataTableBodyState({
+  colSpan,
+  state,
+  errorMessage = "Something went wrong. Try again.",
+  emptyMessage = "No rows match your filters.",
+  loadingMessage = "Loading…",
+  children,
+}: Props) {
+  if (state === "loading") {
+    return (
+      <tr>
+        <td
+          colSpan={colSpan}
+          className="px-4 py-16 text-center text-muted-foreground"
+        >
+          <span className="inline-flex items-center justify-center gap-2">
+            <span
+              className="h-5 w-5 border-2 border-primary border-t-transparent rounded-full animate-spin"
+              aria-hidden
+            />
+            {loadingMessage}
+          </span>
+        </td>
+      </tr>
+    );
+  }
+  if (state === "error") {
+    return (
+      <tr>
+        <td
+          colSpan={colSpan}
+          className="px-4 py-12 text-center text-destructive text-sm"
+        >
+          {errorMessage}
+        </td>
+      </tr>
+    );
+  }
+  if (state === "empty") {
+    return (
+      <EmptyState
+        colSpan={colSpan}
+        className="px-4 py-12 text-muted-foreground"
+        message={emptyMessage}
+      />
+    );
+  }
+  return <>{children}</>;
+}

--- a/fluxapay_frontend/src/components/data-table/DataTableCard.tsx
+++ b/fluxapay_frontend/src/components/data-table/DataTableCard.tsx
@@ -1,0 +1,23 @@
+import { type ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+  /** Renders above the main content (e.g. filters) */
+  toolbar?: ReactNode;
+  /** Renders below the main content (e.g. pagination) */
+  footer?: ReactNode;
+};
+
+/**
+ * Consistent card shell for list pages: payments, invoices, webhooks, settlements.
+ */
+export function DataTableCard({ children, className = "", toolbar, footer }: Props) {
+  return (
+    <div className={`bg-card rounded-2xl border shadow-sm overflow-hidden ${className}`.trim()}>
+      {toolbar}
+      {children}
+      {footer}
+    </div>
+  );
+}

--- a/fluxapay_frontend/src/components/data-table/ListPageFilterBar.tsx
+++ b/fluxapay_frontend/src/components/data-table/ListPageFilterBar.tsx
@@ -1,0 +1,23 @@
+import { type ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+  /** When true, use a vertical stack (e.g. presets row + search row). */
+  stack?: boolean;
+};
+
+const barClasses =
+  "p-4 sm:p-6 border-b border-border/60 bg-muted/20";
+
+/**
+ * Shared filter row: same padding, border, and background as other dashboard list pages.
+ */
+export function ListPageFilterBar({ children, className = "", stack = false }: Props) {
+  const layout = stack
+    ? "flex flex-col gap-4"
+    : "flex flex-col sm:flex-row flex-wrap items-stretch sm:items-end gap-3";
+  return (
+    <div className={`${layout} ${barClasses} ${className}`.trim()}>{children}</div>
+  );
+}

--- a/fluxapay_frontend/src/components/data-table/TablePaginationBar.tsx
+++ b/fluxapay_frontend/src/components/data-table/TablePaginationBar.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/Button";
+
+export type TablePaginationBarProps = {
+  page: number;
+  pageSize: number;
+  total: number;
+  loading?: boolean;
+  onPageChange: (page: number) => void;
+  className?: string;
+};
+
+/**
+ * Consistent “Showing X–Y of Z” and prev/next controls for server-driven lists.
+ */
+export function TablePaginationBar({
+  page,
+  pageSize,
+  total,
+  loading = false,
+  onPageChange,
+  className = "",
+}: TablePaginationBarProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize) || 1);
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, total);
+
+  return (
+    <div
+      className={`flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 sm:px-6 py-4 text-sm text-muted-foreground border-t border-border/60 ${className}`.trim()}
+    >
+      <p>
+        {total === 0
+          ? "No results"
+          : `Showing ${start}–${end} of ${total}`}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled={page <= 1 || loading}
+          onClick={() => onPageChange(page - 1)}
+        >
+          Previous
+        </Button>
+        <span className="text-xs tabular-nums px-1">
+          {page} / {totalPages}
+        </span>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled={page >= totalPages || loading || total === 0}
+          onClick={() => onPageChange(page + 1)}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/fluxapay_frontend/src/components/data-table/index.ts
+++ b/fluxapay_frontend/src/components/data-table/index.ts
@@ -1,0 +1,4 @@
+export { DataTableCard } from "./DataTableCard";
+export { ListPageFilterBar } from "./ListPageFilterBar";
+export { TablePaginationBar, type TablePaginationBarProps } from "./TablePaginationBar";
+export { DataTableBodyState } from "./DataTableBodyState";

--- a/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementFilters.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementFilters.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { ListPageFilterBar } from "@/components/data-table";
+
 type Props = {
     status: string;
     currency: string;
@@ -18,8 +20,8 @@ export function SettlementFilters({
     onDateChange,
 }: Props) {
     return (
-        <div className="rounded-xl border bg-card p-4 shadow">
-            <div className="grid gap-4 md:grid-cols-4">
+        <ListPageFilterBar>
+            <div className="grid gap-4 md:grid-cols-4 w-full">
                 {/* Status */}
                 <div>
                     <label className="text-sm font-medium mb-1.5 block">Status</label>
@@ -76,6 +78,6 @@ export function SettlementFilters({
                     />
                 </div>
             </div>
-        </div>
+        </ListPageFilterBar>
     );
 }

--- a/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementPage.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementPage.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { DollarSign, TrendingUp, Clock, Calendar } from "lucide-react";
 
+import { DataTableCard } from "@/components/data-table";
 import { StatCard } from "./StatCard";
 import { SettlementFilters } from "./SettlementFilters";
 import { SettlementsTable } from "./SettlementsTable";
@@ -81,18 +82,24 @@ export default function SettlementsPage() {
         />
       </div>
 
-      {/* Filters */}
-      <SettlementFilters
-        status={status}
-        currency={currency}
-        date={date}
-        onStatusChange={setStatus}
-        onCurrencyChange={setCurrency}
-        onDateChange={setDate}
-      />
-
-      {/* Table */}
-      <SettlementsTable settlements={filtered} onSelect={setSelected} />
+      <DataTableCard
+        toolbar={
+          <SettlementFilters
+            status={status}
+            currency={currency}
+            date={date}
+            onStatusChange={setStatus}
+            onCurrencyChange={setCurrency}
+            onDateChange={setDate}
+          />
+        }
+      >
+        <SettlementsTable
+          settlements={filtered}
+          onSelect={setSelected}
+          isLoading={isLoading}
+        />
+      </DataTableCard>
 
       {/* Modal */}
       {selected && (

--- a/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementsTable.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementsTable.tsx
@@ -1,17 +1,19 @@
 'use client';
 
 import { FileText } from 'lucide-react';
-import EmptyState from '@/components/EmptyState';
+import { DataTableBodyState } from '@/components/data-table';
 import { Settlement } from '../types';
 
 type Props = {
     settlements: Settlement[];
     onSelect: (settlement: Settlement) => void;
+    isLoading?: boolean;
+    error?: string | null;
 };
 
-export function SettlementsTable({ settlements, onSelect }: Props) {
+export function SettlementsTable({ settlements, onSelect, isLoading = false, error = null }: Props) {
     return (
-        <div className="rounded-xl border bg-card shadow overflow-hidden">
+        <div className="bg-card shadow overflow-hidden">
             <div className="overflow-x-auto">
                 <table className="w-full">
                     <thead className="bg-muted/50 border-b">
@@ -44,14 +46,21 @@ export function SettlementsTable({ settlements, onSelect }: Props) {
                     </thead>
 
                     <tbody className="divide-y">
-                        {settlements.length === 0 ? (
-                            <EmptyState
-                                colSpan={8}
-                                className="py-12 text-muted-foreground"
-                                message="No settlements found matching your filters."
-                            />
-                        ) : (
-                            settlements.map((settlement) => (
+                        <DataTableBodyState
+                            colSpan={8}
+                            state={
+                                error
+                                    ? 'error'
+                                    : isLoading
+                                        ? 'loading'
+                                        : settlements.length === 0
+                                            ? 'empty'
+                                            : 'ready'
+                            }
+                            errorMessage={error ?? undefined}
+                            emptyMessage="No settlements found matching your filters."
+                        >
+                            {settlements.map((settlement) => (
                                 <tr
                                     key={settlement.id}
                                     onClick={() => onSelect(settlement)}
@@ -101,8 +110,8 @@ export function SettlementsTable({ settlements, onSelect }: Props) {
                                         {settlement.bankReference}
                                     </td>
                                 </tr>
-                            ))
-                        )}
+                            ))}
+                        </DataTableBodyState>
                     </tbody>
                 </table>
             </div>

--- a/fluxapay_frontend/src/features/dashboard/invoices/InvoicesTable.tsx
+++ b/fluxapay_frontend/src/features/dashboard/invoices/InvoicesTable.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "@/components/Badge";
-import EmptyState from "@/components/EmptyState";
+import { DataTableBodyState } from "@/components/data-table";
 import { Invoice, InvoiceStatus } from "./invoices-mock";
 import { ChevronDown, ChevronUp, Copy, Eye } from "lucide-react";
 import { useState } from "react";
@@ -7,6 +7,8 @@ import { useState } from "react";
 interface InvoicesTableProps {
   invoices: Invoice[];
   onRowClick: (invoice: Invoice) => void;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 interface SortIconProps {
@@ -34,12 +36,19 @@ const getStatusBadge = (status: InvoiceStatus) => {
       return <Badge variant="error">Overdue</Badge>;
     case "unpaid":
       return <Badge variant="secondary">Unpaid</Badge>;
+    case "cancelled":
+      return <Badge variant="secondary">Cancelled</Badge>;
     default:
       return <Badge>{status}</Badge>;
   }
 };
 
-export const InvoicesTable = ({ invoices, onRowClick }: InvoicesTableProps) => {
+export const InvoicesTable = ({
+  invoices,
+  onRowClick,
+  isLoading = false,
+  error = null,
+}: InvoicesTableProps) => {
   const [sortConfig, setSortConfig] = useState<{
     key: keyof Invoice;
     direction: "asc" | "desc";
@@ -62,7 +71,7 @@ export const InvoicesTable = ({ invoices, onRowClick }: InvoicesTableProps) => {
   });
 
   return (
-    <div className="rounded-xl border bg-card overflow-hidden">
+    <div className="bg-card overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm text-left">
           <thead>
@@ -104,14 +113,21 @@ export const InvoicesTable = ({ invoices, onRowClick }: InvoicesTableProps) => {
             </tr>
           </thead>
           <tbody className="divide-y">
-            {sorted.length === 0 ? (
-              <EmptyState
-                colSpan={6}
-                className="px-4 py-12 text-muted-foreground"
-                message="No invoices found matching your filters."
-              />
-            ) : (
-              sorted.map((invoice) => (
+            <DataTableBodyState
+              colSpan={6}
+              state={
+                error
+                  ? "error"
+                  : isLoading
+                    ? "loading"
+                    : sorted.length === 0
+                      ? "empty"
+                      : "ready"
+              }
+              errorMessage={error ?? undefined}
+              emptyMessage="No invoices found."
+            >
+              {sorted.map((invoice) => (
                 <tr
                   key={invoice.id}
                   className="group hover:bg-muted/50 cursor-pointer transition-colors"
@@ -122,7 +138,9 @@ export const InvoicesTable = ({ invoices, onRowClick }: InvoicesTableProps) => {
                   </td>
                   <td className="px-4 py-4">
                     <div className="flex flex-col">
-                      <span className="font-medium">{invoice.customer_name}</span>
+                      <span className="font-medium">
+                        {invoice.customer_name || "—"}
+                      </span>
                       <span className="text-xs text-muted-foreground">
                         {invoice.customer_email}
                       </span>
@@ -164,8 +182,8 @@ export const InvoicesTable = ({ invoices, onRowClick }: InvoicesTableProps) => {
                     </div>
                   </td>
                 </tr>
-              ))
-            )}
+              ))}
+            </DataTableBodyState>
           </tbody>
         </table>
       </div>

--- a/fluxapay_frontend/src/features/dashboard/invoices/invoices-mock.ts
+++ b/fluxapay_frontend/src/features/dashboard/invoices/invoices-mock.ts
@@ -1,4 +1,4 @@
-export type InvoiceStatus = "unpaid" | "pending" | "paid" | "overdue";
+export type InvoiceStatus = "unpaid" | "pending" | "paid" | "overdue" | "cancelled";
 
 export interface LineItem {
   description: string;

--- a/fluxapay_frontend/src/features/dashboard/payments/PaymentsFilters.tsx
+++ b/fluxapay_frontend/src/features/dashboard/payments/PaymentsFilters.tsx
@@ -1,3 +1,4 @@
+import { ListPageFilterBar } from "@/components/data-table";
 import { Input } from "@/components/Input";
 import { Select } from "@/components/Select";
 import { Button } from "@/components/Button";
@@ -111,7 +112,7 @@ export const PaymentsFilters = memo(({
     };
 
     return (
-        <div className="flex flex-col gap-4 mb-6 bg-slate-50 p-4 rounded-xl border border-slate-100">
+        <ListPageFilterBar stack>
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                 <div className="flex items-center gap-3 w-full md:w-auto">
                     <span className="text-sm font-semibold text-slate-700 whitespace-nowrap">Saved Filters:</span>
@@ -184,7 +185,7 @@ export const PaymentsFilters = memo(({
                     </Select>
                 </div>
             </div>
-        </div>
+        </ListPageFilterBar>
     );
 });
 PaymentsFilters.displayName = "PaymentsFilters";

--- a/fluxapay_frontend/src/features/dashboard/payments/PaymentsTable.tsx
+++ b/fluxapay_frontend/src/features/dashboard/payments/PaymentsTable.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "@/components/Badge";
-import EmptyState from "@/components/EmptyState";
+import { DataTableBodyState } from "@/components/data-table";
 import { Payment, PaymentStatus } from "./payments-mock";
 import { ChevronDown, ChevronUp, Copy, Eye } from "lucide-react";
 import { useState, useMemo, memo, useCallback } from "react";
@@ -7,6 +7,8 @@ import { useState, useMemo, memo, useCallback } from "react";
 interface PaymentsTableProps {
   payments: Payment[];
   onRowClick: (payment: Payment) => void;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 interface SortIconProps {
@@ -123,7 +125,12 @@ const PaymentRow = memo(({ payment, onRowClick }: PaymentRowProps) => {
 });
 PaymentRow.displayName = "PaymentRow";
 
-export const PaymentsTable = ({ payments, onRowClick }: PaymentsTableProps) => {
+export const PaymentsTable = ({
+  payments,
+  onRowClick,
+  isLoading = false,
+  error = null,
+}: PaymentsTableProps) => {
   const [sortConfig, setSortConfig] = useState<{
     key: keyof Payment;
     direction: "asc" | "desc";
@@ -150,7 +157,7 @@ export const PaymentsTable = ({ payments, onRowClick }: PaymentsTableProps) => {
   }, [payments, sortConfig]);
 
   return (
-    <div className="rounded-xl border bg-card overflow-hidden">
+    <div className="bg-card overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm text-left">
           <thead>
@@ -191,21 +198,28 @@ export const PaymentsTable = ({ payments, onRowClick }: PaymentsTableProps) => {
             </tr>
           </thead>
           <tbody className="divide-y">
-            {sortedPayments.length === 0 ? (
-              <EmptyState
-                colSpan={7}
-                className="px-4 py-12 text-muted-foreground"
-                message="No payments found matching your filters."
-              />
-            ) : (
-              sortedPayments.map((payment) => (
+            <DataTableBodyState
+              colSpan={7}
+              state={
+                error
+                  ? "error"
+                  : isLoading
+                    ? "loading"
+                    : sortedPayments.length === 0
+                      ? "empty"
+                      : "ready"
+              }
+              errorMessage={error ?? undefined}
+              emptyMessage="No payments found matching your filters."
+            >
+              {sortedPayments.map((payment) => (
                 <PaymentRow
                   key={payment.id}
                   payment={payment}
                   onRowClick={onRowClick}
                 />
-              ))
-            )}
+              ))}
+            </DataTableBodyState>
           </tbody>
         </table>
       </div>

--- a/fluxapay_frontend/src/features/settings/components/SettingsPage.tsx
+++ b/fluxapay_frontend/src/features/settings/components/SettingsPage.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Link from "next/link";
 import Input from "@/components/Input";
 import { Button } from "@/components/Button";
 import { Modal } from "@/components/Modal";
 import { api, ApiError, clearToken } from "@/lib/api";
+import { DOCS_URLS } from "@/lib/docs";
+import { isValidHttpsWebhookUrl } from "@/lib/webhookUrl";
 
 import {
   Copy,
@@ -220,13 +223,12 @@ export default function SettingsPage() {
   const handleWebhookUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setWebhookUrl(value);
-
-    // Validate HTTPS
-    if (value && !value.startsWith("https://")) {
-      setWebhookError("Webhook URL must start with https://");
-    } else {
+    if (!value.trim()) {
       setWebhookError("");
+      return;
     }
+    const v = isValidHttpsWebhookUrl(value);
+    setWebhookError(v.ok ? "" : v.message);
   };
 
   // Handle Webhook Save
@@ -642,7 +644,16 @@ export default function SettingsPage() {
               error={webhookError}
             />
             <p className="text-xs text-muted-foreground mt-2">
-              We&apos;ll send payment notifications to this endpoint.
+              We&apos;ll send payment notifications to this public HTTPS endpoint. Learn how to{" "}
+              <Link
+                href={DOCS_URLS.WEBHOOK_VERIFICATION}
+                className="text-primary font-medium underline"
+                target="_blank"
+                rel="noreferrer"
+              >
+                verify webhook signatures
+              </Link>
+              . Use the Webhooks page to send a test delivery.
             </p>
           </div>
 
@@ -674,7 +685,7 @@ export default function SettingsPage() {
             </Button>
           </div>
 
-          {webhookError && !webhookError.includes("https://") && (
+          {webhookError && (
             <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-red-800">
               <p className="text-sm">{webhookError}</p>
             </div>

--- a/fluxapay_frontend/src/features/webhooks/WebhookTest.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhookTest.tsx
@@ -3,173 +3,225 @@ import { Button } from "@/components/Button";
 import { Select } from "@/components/Select";
 import { Input } from "@/components/Input";
 import { useState } from "react";
-import { Send, CheckCircle2 } from "lucide-react";
+import { Send, CheckCircle2, XCircle } from "lucide-react";
+import Link from "next/link";
 import toast from "react-hot-toast";
 import { toastApiError } from "@/lib/toastApiError";
 import { api } from "@/lib/api";
+import { DOCS_URLS } from "@/lib/docs";
+import { isValidHttpsWebhookUrl } from "@/lib/webhookUrl";
 
 interface WebhookTestProps {
-    isOpen: boolean;
-    onClose: () => void;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function snippet(text: string, max = 400) {
+  const t = text?.trim() ?? "";
+  if (t.length <= max) return t;
+  return `${t.slice(0, max)}…`;
 }
 
 export const WebhookTest = ({ isOpen, onClose }: WebhookTestProps) => {
-    const [eventType, setEventType] = useState("payment_completed");
-    const [endpoint, setEndpoint] = useState("");
-    const [isTesting, setIsTesting] = useState(false);
-    const [testResult, setTestResult] = useState<{
-        status: number;
-        message: string;
-    } | null>(null);
+  const [eventType, setEventType] = useState("payment_completed");
+  const [endpoint, setEndpoint] = useState("");
+  const [isTesting, setIsTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{
+    ok: boolean;
+    status: number;
+    detail: string;
+    bodySnippet?: string;
+  } | null>(null);
 
-    const getMockPayload = (type: string) => {
-        switch (type) {
-            case "payment_completed":
-                return {
-                    event_type: "payment_completed",
-                    data: {
-                        paymentId: "pay_test_123",
-                        amount: 500,
-                        currency: "USDC",
-                        status: "confirmed",
-                    },
-                };
-            case "payment_failed":
-                return {
-                    event_type: "payment_failed",
-                    data: {
-                        paymentId: "pay_test_456",
-                        amount: 100,
-                        currency: "XLM",
-                        status: "failed",
-                        reason: "insufficient_funds",
-                    },
-                };
-            case "refund_completed":
-                return {
-                    event_type: "refund_completed",
-                    data: {
-                        refundId: "rf_test_789",
-                        paymentId: "pay_test_123",
-                        amount: 50,
-                        currency: "USDC",
-                        status: "completed",
-                    },
-                };
-            default:
-                return { event_type: type, data: {} };
-        }
-    };
+  const getMockPayload = (type: string) => {
+    switch (type) {
+      case "payment_completed":
+        return {
+          event_type: "payment_completed",
+          data: {
+            paymentId: "pay_test_123",
+            amount: 500,
+            currency: "USDC",
+            status: "confirmed",
+          },
+        };
+      case "payment_failed":
+        return {
+          event_type: "payment_failed",
+          data: {
+            paymentId: "pay_test_456",
+            amount: 100,
+            currency: "XLM",
+            status: "failed",
+            reason: "insufficient_funds",
+          },
+        };
+      case "refund_completed":
+        return {
+          event_type: "refund_completed",
+          data: {
+            refundId: "rf_test_789",
+            paymentId: "pay_test_123",
+            amount: 50,
+            currency: "USDC",
+            status: "completed",
+          },
+        };
+      default:
+        return { event_type: type, data: {} };
+    }
+  };
 
-    const handleTest = async () => {
-        if (!endpoint) return;
-        setIsTesting(true);
-        setTestResult(null);
+  const urlCheck = isValidHttpsWebhookUrl(endpoint);
+  const urlError = endpoint.trim() ? (urlCheck.ok ? "" : urlCheck.message) : "";
 
-        try {
-            const res = await api.webhooks.sendTest({
-                event_type: eventType,
-                endpoint_url: endpoint,
-            });
-            // Backend returns { message, data: { http_status, response_body, ... } }
-            const httpStatus = Number(res?.data?.http_status ?? 200);
-            setTestResult({ status: httpStatus, message: "OK" });
-            toast.success("Test webhook sent.");
-        } catch (e) {
-            toastApiError(e);
-            setTestResult({ status: 0, message: "Failed" });
-        } finally {
-            setIsTesting(false);
-        }
-    };
+  const handleTest = async () => {
+    if (!urlCheck.ok) {
+      toast.error(urlCheck.message);
+      return;
+    }
+    setIsTesting(true);
+    setTestResult(null);
 
-    return (
-        <Modal isOpen={isOpen} onClose={onClose} title="Test Webhook Configuration">
-            <div className="space-y-6">
-                <p className="text-sm text-muted-foreground">
-                    Send a mock webhook event to your configured endpoint to ensure your
-                    integration is handling events correctly.
-                </p>
+    try {
+      const res = (await api.webhooks.sendTest({
+        event_type: eventType,
+        endpoint_url: endpoint.trim(),
+      })) as {
+        data?: { http_status?: number; response_body?: string; status?: string };
+      };
+      const httpStatus = Number(res?.data?.http_status ?? 0);
+      const ok = httpStatus >= 200 && httpStatus < 300;
+      const bodyRaw =
+        typeof res?.data?.response_body === "string" ? res.data.response_body : "";
+      setTestResult({
+        ok,
+        status: httpStatus,
+        detail: res?.data?.status ? String(res.data.status) : (ok ? "delivered" : "failed"),
+        bodySnippet: bodyRaw ? snippet(bodyRaw) : undefined,
+      });
+      if (ok) {
+        toast.success("Test webhook delivered. Verify the signature on your server.");
+      } else {
+        toast.error(`Test webhook returned HTTP ${httpStatus || "error"}.`);
+      }
+    } catch (e) {
+      toastApiError(e);
+      setTestResult({
+        ok: false,
+        status: 0,
+        detail: e instanceof Error ? e.message : "Request failed",
+      });
+    } finally {
+      setIsTesting(false);
+    }
+  };
 
-                <div className="space-y-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-1">
-                            Event Type
-                        </label>
-                        <Select
-                            className="w-full"
-                            value={eventType}
-                            onChange={(e) => setEventType(e.target.value)}
-                        >
-                            <option value="payment_completed">payment_completed</option>
-                            <option value="payment_failed">payment_failed</option>
-                            <option value="payment_pending">payment_pending</option>
-                            <option value="refund_completed">refund_completed</option>
-                            <option value="refund_failed">refund_failed</option>
-                        </Select>
-                    </div>
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Test Webhook Configuration">
+      <div className="space-y-6">
+        <p className="text-sm text-muted-foreground">
+          Send a signed test request to your HTTPS endpoint. Compare with{" "}
+          <Link
+            href={DOCS_URLS.WEBHOOK_VERIFICATION}
+            className="text-primary underline font-medium"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Webhook signature verification
+          </Link>{" "}
+          in the docs to validate the payload.
+        </p>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-1">
-                            Test Endpoint URL
-                        </label>
-                        <Input
-                            placeholder="https://your-domain.com/webhooks/fluxapay"
-                            type="url"
-                            className="w-full"
-                            value={endpoint}
-                            onChange={(e) => setEndpoint(e.target.value)}
-                        />
-                    </div>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Event Type</label>
+            <Select
+              className="w-full"
+              value={eventType}
+              onChange={(e) => setEventType(e.target.value)}
+            >
+              <option value="payment_completed">payment_completed</option>
+              <option value="payment_failed">payment_failed</option>
+              <option value="payment_pending">payment_pending</option>
+              <option value="refund_completed">refund_completed</option>
+              <option value="refund_failed">refund_failed</option>
+            </Select>
+          </div>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-1">
-                            Payload Preview
-                        </label>
-                        <pre className="bg-muted p-4 rounded-md font-mono text-xs overflow-x-auto text-foreground/90 border border-border/50 max-h-48">
-                            {JSON.stringify(getMockPayload(eventType), null, 2)}
-                        </pre>
-                    </div>
-                </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Test endpoint URL (HTTPS only)</label>
+            <Input
+              placeholder="https://your-domain.com/webhooks/fluxapay"
+              type="url"
+              className="w-full"
+              value={endpoint}
+              onChange={(e) => setEndpoint(e.target.value)}
+              error={urlError}
+            />
+          </div>
 
-                {testResult && (
-                    <div className="p-4 bg-success/10 text-success border border-success/20 rounded-lg flex items-start gap-3">
-                        <CheckCircle2 className="h-5 w-5 mt-0.5" />
-                        <div>
-                            <h4 className="font-semibold text-sm">
-                                Test Request Successful
-                            </h4>
-                            <p className="text-xs opacity-90 mt-1 pb-1 font-mono">
-                                HTTP {testResult.status} {testResult.message}
-                            </p>
-                        </div>
-                    </div>
-                )}
+          <div>
+            <label className="block text-sm font-medium mb-1">Payload preview</label>
+            <pre className="bg-muted p-4 rounded-md font-mono text-xs overflow-x-auto text-foreground/90 border border-border/50 max-h-48">
+              {JSON.stringify(getMockPayload(eventType), null, 2)}
+            </pre>
+          </div>
+        </div>
 
-                <div className="flex justify-end gap-3 pt-4 border-t">
-                    <Button variant="outline" onClick={onClose} disabled={isTesting}>
-                        Cancel
-                    </Button>
-                    <Button
-                        variant="default"
-                        className="gap-2"
-                        onClick={handleTest}
-                        disabled={!endpoint || isTesting}
-                    >
-                        {isTesting ? (
-                            <span className="flex items-center gap-2">
-                                <span className="h-4 w-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                                Sending...
-                            </span>
-                        ) : (
-                            <>
-                                <Send className="h-4 w-4" />
-                                Send Test
-                            </>
-                        )}
-                    </Button>
-                </div>
+        {testResult && (
+          <div
+            className={`p-4 rounded-lg border flex items-start gap-3 ${
+              testResult.ok
+                ? "bg-success/10 text-success border-success/20"
+                : "bg-destructive/5 text-destructive border-destructive/20"
+            }`}
+          >
+            {testResult.ok ? (
+              <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
+            ) : (
+              <XCircle className="h-5 w-5 mt-0.5 shrink-0" />
+            )}
+            <div className="min-w-0">
+              <h4 className="font-semibold text-sm">
+                {testResult.ok ? "Delivery response" : "Test did not succeed"}
+              </h4>
+              <p className="text-xs mt-1 font-mono break-all">
+                HTTP {testResult.status} · {testResult.detail}
+              </p>
+              {testResult.bodySnippet && (
+                <pre className="text-[11px] mt-2 p-2 rounded bg-background/50 border border-border/40 overflow-x-auto max-h-28">
+                  {testResult.bodySnippet}
+                </pre>
+              )}
             </div>
-        </Modal>
-    );
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 pt-4 border-t">
+          <Button variant="outline" onClick={onClose} disabled={isTesting}>
+            Close
+          </Button>
+          <Button
+            variant="default"
+            className="gap-2"
+            onClick={handleTest}
+            disabled={!urlCheck.ok || isTesting}
+          >
+            {isTesting ? (
+              <span className="flex items-center gap-2">
+                <span className="h-4 w-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                Sending…
+              </span>
+            ) : (
+              <>
+                <Send className="h-4 w-4" />
+                Send test webhook
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
 };

--- a/fluxapay_frontend/src/features/webhooks/WebhooksFilters.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhooksFilters.tsx
@@ -1,3 +1,4 @@
+import { ListPageFilterBar } from "@/components/data-table";
 import { Input } from "@/components/Input";
 import { Select } from "@/components/Select";
 import { Search } from "lucide-react";
@@ -38,7 +39,7 @@ export const WebhooksFilters = memo(({
         onDateToChange(e.target.value);
     }, [onDateToChange]);
     return (
-        <div className="flex flex-col md:flex-row gap-4 mb-6">
+        <ListPageFilterBar>
             <div className="relative flex-1">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
@@ -81,7 +82,7 @@ export const WebhooksFilters = memo(({
                     onChange={handleDateToChange}
                 />
             </div>
-        </div>
+        </ListPageFilterBar>
     );
 });
 WebhooksFilters.displayName = "WebhooksFilters";

--- a/fluxapay_frontend/src/features/webhooks/WebhooksTable.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhooksTable.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "@/components/Badge";
-import EmptyState from "@/components/EmptyState";
+import { DataTableBodyState } from "@/components/data-table";
 import { WebhookEvent, WebhookStatus } from "./webhooks-mock";
 import { ChevronDown, ChevronUp, Copy, Eye } from "lucide-react";
 import { useState, useMemo, memo, useCallback } from "react";
@@ -8,6 +8,7 @@ interface WebhooksTableProps {
     webhooks: WebhookEvent[];
     onRowClick: (webhook: WebhookEvent) => void;
     loading?: boolean;
+    error?: string | null;
 }
 
 interface SortIconProps {
@@ -111,7 +112,12 @@ const WebhookRow = memo(({ webhook, onRowClick }: WebhookRowProps) => {
 });
 WebhookRow.displayName = "WebhookRow";
 
-export const WebhooksTable = ({ webhooks, onRowClick, loading = false }: WebhooksTableProps) => {
+export const WebhooksTable = ({
+  webhooks,
+  onRowClick,
+  loading = false,
+  error = null,
+}: WebhooksTableProps) => {
     const [sortConfig, setSortConfig] = useState<{
         key: keyof WebhookEvent;
         direction: "asc" | "desc";
@@ -137,8 +143,8 @@ export const WebhooksTable = ({ webhooks, onRowClick, loading = false }: Webhook
         });
     }, [webhooks, sortConfig]);
 
-    return (
-        <div className="rounded-xl border bg-card overflow-hidden">
+  return (
+        <div className="bg-card overflow-hidden">
             <div className="overflow-x-auto">
                 <table className="w-full text-sm text-left">
                     <thead>
@@ -181,21 +187,29 @@ export const WebhooksTable = ({ webhooks, onRowClick, loading = false }: Webhook
                         </tr>
                     </thead>
                     <tbody className="divide-y">
-                        {sortedWebhooks.length === 0 ? (
-                            <EmptyState
-                                colSpan={7}
-                                className="px-4 py-12 text-muted-foreground"
-                                message={loading ? "Loading webhook logs..." : "No webhooks found matching your filters."}
-                            />
-                        ) : (
-                            sortedWebhooks.map((webhook) => (
-                                <WebhookRow
-                                    key={webhook.id}
-                                    webhook={webhook}
-                                    onRowClick={onRowClick}
-                                />
-                            ))
-                        )}
+            <DataTableBodyState
+              colSpan={7}
+              state={
+                error
+                  ? "error"
+                  : loading
+                    ? "loading"
+                    : sortedWebhooks.length === 0
+                      ? "empty"
+                      : "ready"
+              }
+              errorMessage={error ?? undefined}
+              emptyMessage="No webhooks found matching your filters."
+              loadingMessage="Loading webhook logs…"
+            >
+              {sortedWebhooks.map((webhook) => (
+                <WebhookRow
+                  key={webhook.id}
+                  webhook={webhook}
+                  onRowClick={onRowClick}
+                />
+              ))}
+            </DataTableBodyState>
                     </tbody>
                 </table>
             </div>

--- a/fluxapay_frontend/src/lib/api.ts
+++ b/fluxapay_frontend/src/lib/api.ts
@@ -342,12 +342,12 @@ export const api = {
       if (params?.currency) sp.set("currency", params.currency);
       if (params?.date_from) sp.set("date_from", params.date_from);
       if (params?.date_to) sp.set("date_to", params.date_to);
-      return fetchWithAuth(`/api/settlements?${sp.toString()}`);
+      return fetchWithAuth(`/api/v1/settlements?${sp.toString()}`);
     },
-    summary: () => fetchWithAuth("/api/settlements/summary"),
-    getById: (id: string) => fetchWithAuth(`/api/settlements/${id}`),
+    summary: () => fetchWithAuth("/api/v1/settlements/summary"),
+    getById: (id: string) => fetchWithAuth(`/api/v1/settlements/${id}`),
     export: (settlementId: string, format: "pdf" | "csv" = "pdf") =>
-      fetchWithAuth(`/api/settlements/${settlementId}/export?format=${format}`),
+      fetchWithAuth(`/api/v1/settlements/${settlementId}/export?format=${format}`),
     exportRange: async (params: {
       date_from?: string;
       date_to?: string;
@@ -358,7 +358,7 @@ export const api = {
       if (params.date_to) sp.set("date_to", params.date_to);
       sp.set("format", params.format || "csv");
       const response = await fetch(
-        `${API_BASE_URL}/api/settlements/export?${sp.toString()}`,
+        `${API_BASE_URL}/api/v1/settlements/export?${sp.toString()}`,
         { headers: { Authorization: `Bearer ${getToken()}` } },
       );
       if (!response.ok) {
@@ -532,16 +532,31 @@ export const api = {
         body: JSON.stringify(data),
       }),
 
-    list: (params?: {
+    list: async (params?: {
       page?: number;
       limit?: number;
       status?: string;
+      search?: string;
     }) => {
       const sp = new URLSearchParams();
       if (params?.page != null) sp.set("page", String(params.page));
       if (params?.limit != null) sp.set("limit", String(params.limit));
       if (params?.status && params.status !== "all") sp.set("status", params.status);
-      return fetchWithAuth(`/api/v1/invoices?${sp.toString()}`);
+      if (params?.search?.trim()) sp.set("search", params.search.trim());
+      const raw = (await fetchWithAuth(
+        `/api/v1/invoices?${sp.toString()}`,
+      )) as {
+        data?: { invoices?: unknown[] };
+        meta?: { page: number; limit: number; total: number; total_pages?: number };
+      };
+      return {
+        invoices: raw.data?.invoices ?? [],
+        meta: raw.meta ?? {
+          page: params?.page ?? 1,
+          limit: params?.limit ?? 10,
+          total: 0,
+        },
+      };
     },
 
     getById: (invoiceId: string) => fetchWithAuth(`/api/v1/invoices/${invoiceId}`),
@@ -572,17 +587,20 @@ export const api = {
       if (params?.search) sp.set("search", params.search);
       if (params?.page != null) sp.set("page", String(params.page));
       if (params?.limit != null) sp.set("limit", String(params.limit));
-      return fetchWithAuth(`/api/webhooks/logs?${sp.toString()}`);
+      return fetchWithAuth(`/api/v1/webhooks/logs?${sp.toString()}`);
     },
-    logDetails: (logId: string) => fetchWithAuth(`/api/webhooks/logs/${logId}`),
+    logDetails: (logId: string) => fetchWithAuth(`/api/v1/webhooks/logs/${logId}`),
     retry: (logId: string) =>
-      fetchWithAuth(`/api/webhooks/logs/${logId}/retry`, { method: "POST" }),
+      fetchWithAuth(`/api/v1/webhooks/logs/${logId}/retry`, { method: "POST" }),
     sendTest: (data: {
       event_type: string;
       endpoint_url: string;
       payload_override?: Record<string, unknown>;
     }) =>
-      fetchWithAuth("/api/webhooks/test", { method: "POST", body: JSON.stringify(data) }),
+      fetchWithAuth("/api/v1/webhooks/test", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
   },
 
   // Dashboard overview
@@ -592,21 +610,21 @@ export const api = {
       if (params?.from) sp.set("from", params.from);
       if (params?.to) sp.set("to", params.to);
       const q = sp.toString();
-      return fetchWithAuth(`/api/dashboard/overview/metrics${q ? `?${q}` : ""}`);
+      return fetchWithAuth(`/api/v1/dashboard/overview/metrics${q ? `?${q}` : ""}`);
     },
     charts: (params?: { from?: string; to?: string }) => {
       const sp = new URLSearchParams();
       if (params?.from) sp.set("from", params.from);
       if (params?.to) sp.set("to", params.to);
       const q = sp.toString();
-      return fetchWithAuth(`/api/dashboard/overview/charts${q ? `?${q}` : ""}`);
+      return fetchWithAuth(`/api/v1/dashboard/overview/charts${q ? `?${q}` : ""}`);
     },
     activity: (params?: { from?: string; to?: string }) => {
       const sp = new URLSearchParams();
       if (params?.from) sp.set("from", params.from);
       if (params?.to) sp.set("to", params.to);
       const q = sp.toString();
-      return fetchWithAuth(`/api/dashboard/overview/activity${q ? `?${q}` : ""}`);
+      return fetchWithAuth(`/api/v1/dashboard/overview/activity${q ? `?${q}` : ""}`);
     },
   },
 

--- a/fluxapay_frontend/src/lib/docs.ts
+++ b/fluxapay_frontend/src/lib/docs.ts
@@ -6,6 +6,8 @@ export const DOCS_URLS = {
   API_REFERENCE: "/docs/api-reference",
   GETTING_STARTED: "/docs/getting-started",
   AUTHENTICATION: "/docs/authentication",
+  /** Webhook HMAC / signature verification (see on-page section). */
+  WEBHOOK_VERIFICATION: "/docs/authentication#webhook-verification",
   RATE_LIMITS: "/docs/rate-limits",
   FULL_DOCS: "/docs",
   COMMUNITY: "/community",

--- a/fluxapay_frontend/src/lib/webhookUrl.ts
+++ b/fluxapay_frontend/src/lib/webhookUrl.ts
@@ -1,0 +1,27 @@
+/**
+ * Webhook endpoint URLs must be public HTTPS. Localhost is rejected for production-style checks;
+ * use the test modal with a tunneled https URL (e.g. ngrok) if needed.
+ */
+export function isValidHttpsWebhookUrl(raw: string): { ok: true } | { ok: false; message: string } {
+  const s = raw.trim();
+  if (!s) {
+    return { ok: false, message: "Enter a webhook URL." };
+  }
+  let url: URL;
+  try {
+    url = new URL(s);
+  } catch {
+    return { ok: false, message: "Invalid URL." };
+  }
+  if (url.protocol !== "https:") {
+    return { ok: false, message: "Webhook URL must use https://." };
+  }
+  const host = url.hostname.toLowerCase();
+  if (host === "localhost" || host === "127.0.0.1" || host === "[::1]") {
+    return {
+      ok: false,
+      message: "Use a public https URL. For local testing, expose your server with a tunnel and use that URL.",
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
Delivers the four related tracks: shared dashboard list UI, safer webhook configuration, layered API rate limits, and invoice list filters with consistent pagination metadata.

## Issues

### Closes #432 — Consistent tables and filters
**Payments, invoices, webhooks, and settlements** use a shared list layout: `DataTableCard`, `ListPageFilterBar`, `TablePaginationBar`, and `DataTableBodyState` for loading / error / empty. Pagination copy and controls are aligned across list pages.

### Closes #431 — Webhook configuration
**Client-side HTTPS checks** for webhook and test URLs, **“Send test webhook”** with HTTP status and response snippet, **link to webhook signature docs** (`/docs/authentication#webhook-verification`), and **correct `/api/v1/webhooks/...` API paths** in the client.

### Closes #471 — API abuse protection
**Per-IP** cap on all `/api/v1` (with env aliases `PUBLIC_API_IP_RATE_MAX` / `PUBLIC_API_IP_WINDOW_MS`) plus **per-merchant / per–API key** `merchantApiKeyRateLimit` after `authenticateApiKey` (or JWT with `merchantId` on webhook routes), configurable with `MERCHANT_API_KEY_RATE_MAX` and `MERCHANT_API_KEY_RATE_WINDOW_MS`.

### Closes #474 — Invoice list
**Query:** `status`, `search`, `page`, `limit`. **Response:** `meta.total`, `meta.page`, `meta.limit`, `meta.total_pages` with `data.invoices`. Reuses existing Prisma indexes. Dashboard **invoices** page uses server-side search, filters, and pagination.

## Test plan
- [ ] `fluxapay_backend`: `npm run build` / `npm test` as appropriate  
- [ ] `fluxapay_frontend`: `npm run build`  
- [ ] Smoke: payments & webhooks lists, settings webhook URL, test webhook modal, invoices list and pagination  

---

Closes #432  
Closes #431  
Closes #471  
Closes #474