### PR TITLE
[#470] [Frontend] Payments: show “copy payment link” and QR for checkout_url

### DIFF
--- a/fluxapay_frontend/src/app/dashboard/payments/page.tsx
+++ b/fluxapay_frontend/src/app/dashboard/payments/page.tsx
@@ -27,6 +27,8 @@ interface BackendPayment {
   amount: number;
   currency: string;
   status: Payment["status"];
+  checkoutUrl?: string;
+  checkout_url?: string;
   merchantId: string;
   customer_email: string;
   order_id?: string;
@@ -58,6 +60,7 @@ function mapBackendPayment(p: BackendPayment): Payment {
     amount: p.amount,
     currency: p.currency,
     status: p.status,
+    checkoutUrl: p.checkoutUrl ?? p.checkout_url,
     merchantId: p.merchantId,
     customerName: "",
     customerEmail: p.customer_email ?? "",

--- a/fluxapay_frontend/src/features/dashboard/payments/PaymentDetails.tsx
+++ b/fluxapay_frontend/src/features/dashboard/payments/PaymentDetails.tsx
@@ -15,6 +15,8 @@ import { Button } from "@/components/Button";
 import { Input } from "@/components/Input";
 import { Select } from "@/components/Select";
 import type { RefundRecord, RefundReason } from "../refunds/refunds-mock";
+import { QRCodeCanvas } from "qrcode.react";
+import toast from "react-hot-toast";
 
 interface PaymentDetailsProps {
   payment: Payment;
@@ -52,8 +54,13 @@ export const PaymentDetails = ({
   const [formError, setFormError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success("Copied to clipboard.");
+    } catch {
+      toast.error("Unable to copy to clipboard.");
+    }
   };
 
   const paymentRefunds = useMemo(
@@ -182,7 +189,7 @@ export const PaymentDetails = ({
               <div className="group flex items-center gap-2">
                 <code className="text-xs font-mono">{payment.id}</code>
                 <button
-                  onClick={() => copyToClipboard(payment.id)}
+                  onClick={() => void copyToClipboard(payment.id)}
                   className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <Copy className="h-3 w-3" />
@@ -196,13 +203,43 @@ export const PaymentDetails = ({
                   {payment.depositAddress}
                 </code>
                 <button
-                  onClick={() => copyToClipboard(payment.depositAddress)}
+                  onClick={() => void copyToClipboard(payment.depositAddress)}
                   className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <Copy className="h-3 w-3" />
                 </button>
               </div>
             </div>
+            {payment.checkoutUrl && (
+              <div>
+                <p className="text-xs text-muted-foreground">Checkout URL</p>
+                <div className="mt-1 flex items-start gap-2">
+                  <a
+                    href={payment.checkoutUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="min-w-0 break-all text-xs font-mono text-primary hover:underline"
+                  >
+                    {payment.checkoutUrl}
+                  </a>
+                  <button
+                    onClick={() => void copyToClipboard(payment.checkoutUrl!)}
+                    className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    title="Copy checkout URL"
+                  >
+                    <Copy className="h-3 w-3" />
+                  </button>
+                </div>
+                <div className="mt-3 flex justify-center rounded-lg border bg-card p-3">
+                  <QRCodeCanvas
+                    value={payment.checkoutUrl}
+                    size={132}
+                    includeMargin
+                    level="M"
+                  />
+                </div>
+              </div>
+            )}
             {payment.txHash && (
               <div>
                 <p className="text-xs text-muted-foreground">Transaction Hash</p>

--- a/fluxapay_frontend/src/features/dashboard/payments/payments-mock.ts
+++ b/fluxapay_frontend/src/features/dashboard/payments/payments-mock.ts
@@ -9,6 +9,7 @@ export interface Payment {
   amount: number;
   currency: string;
   status: PaymentStatus;
+  checkoutUrl?: string;
   merchantId: string;
   customerName: string;
   customerEmail: string;


### PR DESCRIPTION
Closes #470

## Summary
- propagate `checkout_url` / `checkoutUrl` from backend payment payloads into dashboard payment details model
- add a dedicated Checkout URL block in payment details with:
  - clickable checkout link
  - copy-to-clipboard action
  - QR code generated from checkout URL
- add toast feedback for copy success/failure in payment details actions

## Notes
- attempted to run local build and unit tests, but dependency installation is extremely slow in this environment and did not complete within available execution windows.
