### PR TITLE
[475] [Frontend] Add dashboard notifications center (webhook failures, payouts)

### DIFF
--- a/fluxapay_frontend/src/__tests__/components/NotificationsCenter.test.tsx
+++ b/fluxapay_frontend/src/__tests__/components/NotificationsCenter.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Component tests for dashboard NotificationsCenter
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { NotificationsCenter } from '@/features/dashboard/components/overview/NotificationsCenter';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const mockNotifications = [
+  {
+    id: 'wh-1',
+    category: 'webhook_failure' as const,
+    severity: 'critical' as const,
+    title: 'Webhook delivery failed',
+    description: 'payment.completed → https://example.com/hook',
+    timestamp: '2026-01-01T10:00:00Z',
+    href: '/dashboard/webhooks',
+  },
+  {
+    id: 'pay-1',
+    category: 'payout' as const,
+    severity: 'info' as const,
+    title: 'Payout settled',
+    description: '$500.00 settled',
+    timestamp: '2026-01-01T09:00:00Z',
+    href: '/dashboard/settlements',
+  },
+];
+
+vi.mock('@/hooks/useDashboardNotifications', () => ({
+  useDashboardNotifications: () => ({
+    notifications: mockNotifications,
+    isLoading: false,
+    error: null,
+    unreadCount: 1,
+  }),
+}));
+
+describe('NotificationsCenter', () => {
+  it('renders the heading', () => {
+    render(<NotificationsCenter />);
+    expect(screen.getByText('Notifications Center')).toBeInTheDocument();
+  });
+
+  it('renders notification items', () => {
+    render(<NotificationsCenter />);
+    expect(screen.getByText('Webhook delivery failed')).toBeInTheDocument();
+    expect(screen.getByText('Payout settled')).toBeInTheDocument();
+  });
+
+  it('shows active badge count', () => {
+    render(<NotificationsCenter />);
+    expect(screen.getByText('1 active')).toBeInTheDocument();
+  });
+
+  it('renders loading skeleton when loading', () => {
+    vi.mock('@/hooks/useDashboardNotifications', () => ({
+      useDashboardNotifications: () => ({
+        notifications: [],
+        isLoading: true,
+        error: null,
+        unreadCount: 0,
+      }),
+    }));
+    render(<NotificationsCenter />);
+    // heading still present even during load
+    expect(screen.getByText('Notifications Center')).toBeInTheDocument();
+  });
+
+  it('shows all-clear badge when no unread', () => {
+    vi.mock('@/hooks/useDashboardNotifications', () => ({
+      useDashboardNotifications: () => ({
+        notifications: mockNotifications,
+        isLoading: false,
+        error: null,
+        unreadCount: 0,
+      }),
+    }));
+    render(<NotificationsCenter />);
+    expect(screen.getByText('All clear')).toBeInTheDocument();
+  });
+});

--- a/fluxapay_frontend/src/app/dashboard/notifications/page.tsx
+++ b/fluxapay_frontend/src/app/dashboard/notifications/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { NotificationsCenter } from "@/features/dashboard/components/overview/NotificationsCenter";
+
+export const metadata: Metadata = {
+  title: "Notifications | FluxaPay Dashboard",
+  description: "Monitor webhook failures and payout updates in one dashboard feed.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function NotificationsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Notifications</h2>
+        <p className="text-muted-foreground">
+          Track webhook failures and payout lifecycle updates.
+        </p>
+      </div>
+      <NotificationsCenter />
+    </div>
+  );
+}

--- a/fluxapay_frontend/src/features/dashboard/components/DashboardOverview.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/DashboardOverview.tsx
@@ -5,8 +5,8 @@ import { StatsCards } from "./overview/StatsCards";
 import { ChartsSection } from "./overview/ChartsSection";
 import { RecentActivity } from "./overview/RecentActivity";
 import { QuickActions } from "./overview/QuickActions";
+import { NotificationsCenter } from "./overview/NotificationsCenter";
 import { DateRangePicker } from "./overview/DateRangePicker";
-
 function OverviewContent() {
     return (
         <div className="space-y-4 animate-fade-in">
@@ -18,8 +18,11 @@ function OverviewContent() {
             <StatsCards />
             <ChartsSection />
 
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-12">
                 <RecentActivity />
+                <div className="col-span-1 lg:col-span-3">
+                    <NotificationsCenter compact />
+                </div>
                 <QuickActions />
             </div>
         </div>

--- a/fluxapay_frontend/src/features/dashboard/components/Sidebar.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   FileText,
   RefreshCcw,
   Link2,
+  Bell,
 } from "lucide-react";
 import Image from "next/image";
 import FluxapayLogo from "@/assets/fluxapaylogo.png";
@@ -33,6 +34,7 @@ const navItems = [
   { name: "Settlements", href: "/dashboard/settlements", icon: Landmark },
   { name: "Payment Links", href: "/dashboard/payment-links", icon: Link2 },
   { name: "Webhooks", href: "/dashboard/webhooks", icon: Webhook },
+  { name: "Notifications", href: "/dashboard/notifications", icon: Bell },
   { name: "Analytics", href: "/dashboard/analytics", icon: BarChart3 },
   { name: "Settings", href: "/dashboard/settings", icon: Settings },
   { name: "Developers", href: "/dashboard/developers", icon: Code },

--- a/fluxapay_frontend/src/features/dashboard/components/TopNav.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/TopNav.tsx
@@ -2,7 +2,8 @@
 
 import { Menu, Bell, User } from "lucide-react";
 import { Button } from "@/components/Button";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useDashboardNotifications } from "@/hooks/useDashboardNotifications";
 
 interface TopNavProps {
     onMenuClick: () => void;
@@ -10,6 +11,8 @@ interface TopNavProps {
 
 export function TopNav({ onMenuClick }: TopNavProps) {
     const pathname = usePathname();
+    const router = useRouter();
+    const { unreadCount } = useDashboardNotifications({ webhookLimit: 5, payoutLimit: 5 });
 
     const getTitle = () => {
         if (pathname === "/dashboard") return "Overview";
@@ -38,8 +41,18 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 
             {/* Actions */}
             <div className="flex items-center gap-2">
-                <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-foreground">
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="relative text-muted-foreground hover:text-foreground"
+                    onClick={() => router.push("/dashboard/notifications")}
+                >
                     <Bell className="h-5 w-5" />
+                    {unreadCount > 0 && (
+                        <span className="absolute right-1 top-1 inline-flex min-h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-white">
+                            {unreadCount > 9 ? "9+" : unreadCount}
+                        </span>
+                    )}
                     <span className="sr-only">Notifications</span>
                 </Button>
                 <Button variant="ghost" size="icon" className="ml-2 rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80">

--- a/fluxapay_frontend/src/features/dashboard/components/overview/NotificationsCenter.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/overview/NotificationsCenter.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import Link from "next/link";
+import { Bell, AlertTriangle, Clock3, CheckCircle2, ChevronRight } from "lucide-react";
+import { useDashboardNotifications } from "@/hooks/useDashboardNotifications";
+import { cn } from "@/lib/utils";
+
+interface NotificationsCenterProps {
+  compact?: boolean;
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown time";
+  return date.toLocaleString();
+}
+
+function SeverityIcon({ severity }: { severity: "critical" | "warning" | "info" }) {
+  if (severity === "critical") {
+    return <AlertTriangle className="h-4 w-4 text-red-500" aria-hidden="true" />;
+  }
+  if (severity === "warning") {
+    return <Clock3 className="h-4 w-4 text-amber-500" aria-hidden="true" />;
+  }
+  return <CheckCircle2 className="h-4 w-4 text-emerald-500" aria-hidden="true" />;
+}
+
+export function NotificationsCenter({ compact = false }: NotificationsCenterProps) {
+  const { notifications, isLoading, error, unreadCount } = useDashboardNotifications({
+    webhookLimit: compact ? 5 : 20,
+    payoutLimit: compact ? 5 : 20,
+  });
+
+  const visible = compact ? notifications.slice(0, 6) : notifications;
+
+  return (
+    <section
+      className={cn(
+        "rounded-xl border bg-card text-card-foreground shadow-sm",
+        compact ? "h-full" : "",
+      )}
+      aria-label="Notifications center"
+    >
+      <div className="flex items-center justify-between p-6 pb-2">
+        <div>
+          <h3 className="flex items-center gap-2 text-lg font-semibold leading-none tracking-tight">
+            <Bell className="h-4 w-4" />
+            Notifications Center
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Webhook failures and payout updates in one feed.
+          </p>
+        </div>
+        {unreadCount > 0 ? (
+          <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">
+            {unreadCount} active
+          </span>
+        ) : (
+          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700">
+            All clear
+          </span>
+        )}
+      </div>
+
+      <div className="p-6 pt-4">
+        {error && (
+          <p className="text-sm text-destructive">
+            Failed to load notifications.
+          </p>
+        )}
+
+        {isLoading && (
+          <div className="space-y-3">
+            {[1, 2, 3].map((item) => (
+              <div key={item} className="animate-pulse rounded-lg border p-3">
+                <div className="mb-2 h-4 w-36 rounded bg-muted" />
+                <div className="h-3 w-full rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && !error && visible.length === 0 && (
+          <p className="text-sm text-muted-foreground">No recent notifications.</p>
+        )}
+
+        {!isLoading && !error && visible.length > 0 && (
+          <ul className="space-y-3">
+            {visible.map((item) => (
+              <li key={item.id}>
+                <Link
+                  href={item.href}
+                  className="group block rounded-lg border p-3 transition-colors hover:bg-muted/40"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="flex items-center gap-2 text-sm font-medium">
+                        <SeverityIcon severity={item.severity} />
+                        {item.title}
+                      </p>
+                      <p className="mt-1 break-words text-xs text-muted-foreground">
+                        {item.description}
+                      </p>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        {formatTimestamp(item.timestamp)}
+                      </p>
+                    </div>
+                    <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/fluxapay_frontend/src/hooks/useDashboardNotifications.ts
+++ b/fluxapay_frontend/src/hooks/useDashboardNotifications.ts
@@ -1,0 +1,143 @@
+"use client";
+
+import useSWR from "swr";
+import { api } from "@/lib/api";
+
+type NotificationCategory = "webhook_failure" | "payout";
+type NotificationSeverity = "critical" | "warning" | "info";
+
+export interface DashboardNotification {
+  id: string;
+  category: NotificationCategory;
+  severity: NotificationSeverity;
+  title: string;
+  description: string;
+  timestamp: string;
+  href: string;
+}
+
+interface UseDashboardNotificationsOptions {
+  webhookLimit?: number;
+  payoutLimit?: number;
+}
+
+interface WebhookLogRow {
+  id: string;
+  event_type?: string;
+  endpoint_url?: string;
+  status?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+interface SettlementRow {
+  id: string;
+  amount?: unknown;
+  currency?: string;
+  status?: string;
+  created_at?: string;
+}
+
+function toIso(value: unknown): string {
+  if (typeof value === "string" && value.trim()) return value;
+  return new Date(0).toISOString();
+}
+
+function toNumber(value: unknown): number {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+export function useDashboardNotifications(
+  options: UseDashboardNotificationsOptions = {},
+) {
+  const webhookLimit = options.webhookLimit ?? 10;
+  const payoutLimit = options.payoutLimit ?? 10;
+
+  const key = ["dashboard-notifications", webhookLimit, payoutLimit];
+
+  const { data, error, isLoading, mutate } = useSWR<DashboardNotification[]>(
+    key,
+    async () => {
+      const [webhookRes, settlementRes] = await Promise.all([
+        api.webhooks.logs({ status: "failed", page: 1, limit: webhookLimit }) as Promise<{
+          data?: { logs?: WebhookLogRow[] };
+        }>,
+        api.settlements.list({ page: 1, limit: payoutLimit }) as Promise<{
+          settlements?: SettlementRow[];
+          data?: { settlements?: SettlementRow[] };
+        }>,
+      ]);
+
+      const webhookLogs = webhookRes?.data?.logs ?? [];
+      const settlements =
+        settlementRes?.settlements ?? settlementRes?.data?.settlements ?? [];
+
+      const webhookNotifications: DashboardNotification[] = webhookLogs.map(
+        (log) => ({
+          id: `webhook-${log.id}`,
+          category: "webhook_failure",
+          severity: "critical",
+          title: "Webhook delivery failed",
+          description: `${log.event_type ?? "Event"} to ${log.endpoint_url ?? "endpoint"}`,
+          timestamp: toIso(log.updated_at ?? log.created_at),
+          href: "/dashboard/webhooks",
+        }),
+      );
+
+      const payoutNotifications: DashboardNotification[] = settlements
+        .filter((row) =>
+          ["completed", "pending", "failed"].includes(
+            String(row.status ?? "").toLowerCase(),
+          ),
+        )
+        .map((row) => {
+          const status = String(row.status ?? "pending").toLowerCase();
+          const amount = toNumber(row.amount);
+          const currency = row.currency ?? "USD";
+
+          return {
+            id: `payout-${row.id}`,
+            category: "payout",
+            severity:
+              status === "failed"
+                ? "critical"
+                : status === "pending"
+                  ? "warning"
+                  : "info",
+            title:
+              status === "failed"
+                ? "Payout failed"
+                : status === "pending"
+                  ? "Payout pending"
+                  : "Payout completed",
+            description: `${amount.toLocaleString()} ${currency} • Settlement ${row.id}`,
+            timestamp: toIso(row.created_at),
+            href: "/dashboard/settlements",
+          } as DashboardNotification;
+        });
+
+      return [...webhookNotifications, ...payoutNotifications].sort(
+        (a, b) =>
+          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+      );
+    },
+    {
+      refreshInterval: 60_000,
+      revalidateOnFocus: true,
+    },
+  );
+
+  const notifications = data ?? [];
+  const unreadCount = notifications.filter(
+    (item) => item.severity === "critical" || item.severity === "warning",
+  ).length;
+
+  return {
+    notifications,
+    unreadCount,
+    isLoading,
+    error,
+    refresh: mutate,
+  };
+}


### PR DESCRIPTION
Closes #475

---

## Summary

Implements a unified dashboard notifications center that aggregates webhook delivery failures and payout settlement events into a single real-time feed.

## Changes

- `src/hooks/useDashboardNotifications.ts` — New SWR hook polling failed webhooks and settlements in parallel. Refreshes every 60s. Computes unreadCount (critical + warning).
- `src/features/dashboard/components/overview/NotificationsCenter.tsx` — New card component with severity icons (critical=red, warning=amber, info=green). Each item links to /dashboard/webhooks or /dashboard/settlements. Loading/error/empty states handled.
- `src/app/dashboard/notifications/page.tsx` — New dedicated /dashboard/notifications route.
- `src/features/dashboard/components/DashboardOverview.tsx` — Adds compact NotificationsCenter widget to overview grid.
- `src/features/dashboard/components/TopNav.tsx` — Adds live red badge on Bell icon; clicking navigates to /dashboard/notifications.
- `src/features/dashboard/components/Sidebar.tsx` — Adds Notifications nav item (Bell icon).
- `src/__tests__/components/NotificationsCenter.test.tsx` — Vitest unit tests for the new component.

Closes 475
