### PR TITLE
feat: payment monitor dedupe, bank account update endpoint, webhook replay protection, settlement schedule fix

### DIFF
--- a/fluxapay_backend/src/controllers/merchant.controller.ts
+++ b/fluxapay_backend/src/controllers/merchant.controller.ts
@@ -13,6 +13,7 @@ import {
   rotateWebhookSecretService,
   updateSettlementScheduleService,
   addBankAccountService,
+  updateBankAccountService,
 } from "../services/merchant.service";
 import { AuthRequest } from "../types/express";
 import { validateUserId } from "../helpers/request.helper";
@@ -251,4 +252,25 @@ export const addBankAccount = createController(
     });
   },
   201,
+);
+
+export const updateBankAccount = createController(
+  async (
+    body: {
+      account_name?: string;
+      account_number?: string;
+      bank_name?: string;
+      bank_code?: string;
+      currency?: string;
+      country?: string;
+    },
+    req: AuthRequest,
+  ) => {
+    const merchantId = await validateUserId(req);
+
+    return updateBankAccountService({
+      merchantId,
+      ...body,
+    });
+  },
 );

--- a/fluxapay_backend/src/routes/merchant.route.ts
+++ b/fluxapay_backend/src/routes/merchant.route.ts
@@ -15,13 +15,14 @@ import {
   adminBulkUpdateMerchantStatus,
   updateSettlementSchedule,
   addBankAccount,
+  updateBankAccount,
 } from "../controllers/merchant.controller";
 import { validate } from "../middleware/validation.middleware";
 import * as merchantSchema from "../schemas/merchant.schema";
 import { authenticateApiKey } from "../middleware/apiKeyAuth.middleware";
 import { idempotencyMiddleware } from "../middleware/idempotency.middleware";
 import { adminAuth } from "../middleware/adminAuth.middleware";
-import { updateSettlementScheduleSchema, bankAccountSchema } from "../schemas/merchant.schema";
+import { updateSettlementScheduleSchema, bankAccountSchema, updateBankAccountSchema } from "../schemas/merchant.schema";
 import { authRateLimit, merchantApiKeyRateLimit, merchantRateLimit } from "../middleware/rateLimit.middleware";
 
 const router = Router();
@@ -491,6 +492,50 @@ router.post(
   authenticateApiKey, merchantApiKeyRateLimit(),
   validate(bankAccountSchema),
   addBankAccount,
+);
+
+/**
+ * @swagger
+ * /api/v1/merchants/me/bank-account:
+ *   patch:
+ *     summary: Update existing bank account details
+ *     tags: [Merchants]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               account_name:
+ *                 type: string
+ *               account_number:
+ *                 type: string
+ *               bank_name:
+ *                 type: string
+ *               bank_code:
+ *                 type: string
+ *               currency:
+ *                 type: string
+ *               country:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Bank account updated
+ *       400:
+ *         description: Validation error (e.g. currency/country mismatch)
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: No bank account found (use POST to create)
+ */
+router.patch(
+  "/me/bank-account",
+  authenticateApiKey, merchantApiKeyRateLimit(),
+  validate(updateBankAccountSchema),
+  updateBankAccount,
 );
 
 export default router;

--- a/fluxapay_backend/src/schemas/merchant.schema.ts
+++ b/fluxapay_backend/src/schemas/merchant.schema.ts
@@ -79,6 +79,35 @@ export const bankAccountSchema = z.object({
   country: z.string().min(2, 'Country is required'),
 });
 
+const bankAccountBaseFields = z.object({
+  account_name: z.string().min(2, 'Account name is required').optional(),
+  account_number: z.string().min(5, 'Account number is required').optional(),
+  bank_name: z.string().min(2, 'Bank name is required').optional(),
+  bank_code: z.string().optional(),
+  currency: z.string().min(3, 'Currency is required').optional(),
+  country: z.string().min(2, 'Country is required').optional().refine(
+    val => val === undefined || allowedCountryCodes.includes(val),
+    { message: 'Invalid country code' },
+  ),
+});
+
+export const updateBankAccountSchema = bankAccountBaseFields
+  .refine(data => Object.keys(data).some(k => (data as any)[k] !== undefined), {
+    message: 'At least one field must be provided',
+  })
+  .superRefine((data, ctx) => {
+    if (data.country && data.currency) {
+      const entry = countryMap.find(x => x.countryCode === data.country);
+      if (entry && entry.currencyCode !== data.currency) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Currency ${data.currency} is not valid for country ${data.country}. Expected ${entry.currencyCode}.`,
+          path: ['currency'],
+        });
+      }
+    }
+  });
+
 const checkoutLogoUrlField = z
   .union([z.string().max(2048), z.literal(''), z.null()])
   .optional()

--- a/fluxapay_backend/src/services/__tests__/paymentMonitor.service.test.ts
+++ b/fluxapay_backend/src/services/__tests__/paymentMonitor.service.test.ts
@@ -205,4 +205,153 @@ describe('PaymentMonitor Service Logic', () => {
       });
     });
   });
+
+  describe('Dedupe by tx hash', () => {
+    it('should skip a transaction whose hash matches the already-stored transaction_hash', () => {
+      const payment = {
+        id: 'payment_1',
+        stellar_address: 'GTEST123',
+        last_paging_token: null,
+        transaction_hash: 'already_seen_tx',
+        amount: 100,
+        status: PaymentStatus.PENDING,
+      };
+
+      const records = [
+        {
+          paging_token: '11111',
+          type: 'payment',
+          asset_type: 'credit_alphanum4',
+          asset_code: 'USDC',
+          asset_issuer: 'GBBD47IF6LWK7P7MDEVSCWT73IQIGCEZHR7OMXMBZQ3ZONN2T4U6W23Y',
+          transaction_hash: 'already_seen_tx',
+          from: 'G_PAYER',
+        },
+      ];
+
+      let latestPagingToken = payment.last_paging_token;
+      let latestTxHash: string | undefined;
+
+      for (const record of records) {
+        if (record.paging_token && (!latestPagingToken || record.paging_token > (latestPagingToken as string))) {
+          latestPagingToken = record.paging_token;
+        }
+        if (record.type === 'payment' && record.asset_code === 'USDC') {
+          // Dedupe guard
+          if (record.transaction_hash === payment.transaction_hash) continue;
+          if (!latestTxHash) latestTxHash = record.transaction_hash;
+        }
+      }
+
+      // Paging token is updated so we advance past this record next tick
+      expect(latestPagingToken).toBe('11111');
+      // But no new tx hash should be set (already processed)
+      expect(latestTxHash).toBeUndefined();
+    });
+
+    it('should process a new transaction when its hash differs from the stored one', () => {
+      const payment = {
+        id: 'payment_1',
+        stellar_address: 'GTEST123',
+        last_paging_token: '00001',
+        transaction_hash: 'old_tx',
+        amount: 100,
+        status: PaymentStatus.PENDING,
+      };
+
+      const records = [
+        {
+          paging_token: '00002',
+          type: 'payment',
+          asset_type: 'credit_alphanum4',
+          asset_code: 'USDC',
+          asset_issuer: 'GBBD47IF6LWK7P7MDEVSCWT73IQIGCEZHR7OMXMBZQ3ZONN2T4U6W23Y',
+          transaction_hash: 'new_tx',
+          from: 'G_PAYER',
+        },
+      ];
+
+      let latestPagingToken = payment.last_paging_token;
+      let latestTxHash: string | undefined;
+
+      for (const record of records) {
+        if (record.paging_token && (!latestPagingToken || record.paging_token > latestPagingToken)) {
+          latestPagingToken = record.paging_token;
+        }
+        if (record.type === 'payment' && record.asset_code === 'USDC') {
+          if (record.transaction_hash === payment.transaction_hash) continue;
+          if (!latestTxHash) latestTxHash = record.transaction_hash;
+        }
+      }
+
+      expect(latestPagingToken).toBe('00002');
+      expect(latestTxHash).toBe('new_tx');
+    });
+
+    it('should update last_paging_token even when no new tx hash is found', async () => {
+      const mockPayment = {
+        id: 'payment_1',
+        stellar_address: 'GTEST123',
+        last_paging_token: '11111',
+        transaction_hash: 'already_seen_tx',
+        amount: 100,
+        status: PaymentStatus.PENDING,
+      };
+
+      mockPrisma.payment.findMany.mockResolvedValue([mockPayment]);
+      mockServer.loadAccount.mockResolvedValue({
+        balances: [{ asset_code: 'USDC', asset_issuer: 'GBBD47IF6LWK7P7MDEVSCWT73IQIGCEZHR7OMXMBZQ3ZONN2T4U6W23Y', balance: '100.0' }],
+      });
+      mockServer.call.mockResolvedValue({
+        records: [
+          {
+            paging_token: '22222',
+            type: 'payment',
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USDC',
+            asset_issuer: 'GBBD47IF6LWK7P7MDEVSCWT73IQIGCEZHR7OMXMBZQ3ZONN2T4U6W23Y',
+            transaction_hash: 'already_seen_tx',
+            from: 'G_PAYER',
+          },
+        ],
+      });
+      mockPrisma.payment.update.mockResolvedValue({});
+
+      // Simulate the dedupe + paging-token update path
+      const payments = await mockPrisma.payment.findMany({});
+      for (const payment of payments) {
+        const account = await mockServer.loadAccount(payment.stellar_address);
+        void account;
+        const transactions = await mockServer.payments().forAccount(payment.stellar_address).order('desc').limit(10).call();
+
+        let latestPagingToken = payment.last_paging_token;
+        let latestTxHash: string | undefined;
+
+        for (const record of transactions.records) {
+          if (record.paging_token && (!latestPagingToken || record.paging_token > latestPagingToken)) {
+            latestPagingToken = record.paging_token;
+          }
+          if (record.type === 'payment' && record.asset_code === 'USDC') {
+            if (record.transaction_hash === payment.transaction_hash) continue;
+            if (!latestTxHash) latestTxHash = record.transaction_hash;
+          }
+        }
+
+        // No new tx hash but paging token advanced — still persist the token
+        if (!latestTxHash && latestPagingToken && latestPagingToken !== payment.last_paging_token) {
+          await mockPrisma.payment.update({
+            where: { id: payment.id },
+            data: { last_paging_token: latestPagingToken, last_seen_at: expect.any(Date) },
+          });
+        }
+      }
+
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'payment_1' },
+          data: expect.objectContaining({ last_paging_token: '22222' }),
+        }),
+      );
+    });
+  });
 });

--- a/fluxapay_backend/src/services/__tests__/webhook.service.test.ts
+++ b/fluxapay_backend/src/services/__tests__/webhook.service.test.ts
@@ -1,4 +1,4 @@
-import { WebhookDispatcher, createAndDeliverWebhook, deliverWebhook, generateWebhookSignature, getDeadLetterQueueService, requeueWebhookService } from "../webhook.service";
+import { WebhookDispatcher, createAndDeliverWebhook, deliverWebhook, generateWebhookSignature, getDeadLetterQueueService, requeueWebhookService, verifyWebhookTimestamp } from "../webhook.service";
 import { PrismaClient } from "../../generated/client/client";
 
 // Define mock functions inside the factory to avoid jest-hoisting TDZ issues with const
@@ -406,5 +406,32 @@ describe("DLQ services", () => {
     await expect(requeueWebhookService({ log_id: "missing" })).rejects.toEqual(
       expect.objectContaining({ status: 404, message: "Webhook log not found" })
     );
+  });
+});
+
+describe("verifyWebhookTimestamp (replay protection)", () => {
+  it("accepts a timestamp within the default 5-minute window", () => {
+    const ts = new Date(Date.now() - 60_000).toISOString(); // 1 minute ago
+    expect(verifyWebhookTimestamp(ts)).toBe(true);
+  });
+
+  it("rejects a timestamp older than the window", () => {
+    const ts = new Date(Date.now() - 6 * 60_000).toISOString(); // 6 minutes ago
+    expect(verifyWebhookTimestamp(ts)).toBe(false);
+  });
+
+  it("rejects a timestamp in the future", () => {
+    const ts = new Date(Date.now() + 10_000).toISOString(); // 10 seconds ahead
+    expect(verifyWebhookTimestamp(ts)).toBe(false);
+  });
+
+  it("rejects an invalid timestamp string", () => {
+    expect(verifyWebhookTimestamp("not-a-date")).toBe(false);
+  });
+
+  it("respects a custom window", () => {
+    const ts = new Date(Date.now() - 10_000).toISOString(); // 10 seconds ago
+    expect(verifyWebhookTimestamp(ts, 5_000)).toBe(false);  // 5-second window
+    expect(verifyWebhookTimestamp(ts, 30_000)).toBe(true);  // 30-second window
   });
 });

--- a/fluxapay_backend/src/services/merchant.service.ts
+++ b/fluxapay_backend/src/services/merchant.service.ts
@@ -3,6 +3,7 @@ import {
   normalizeCheckoutAccentHex,
   normalizeCheckoutLogoUrl,
 } from "../utils/checkout-branding.util";
+import { countryMap } from "../utils/country-map.util";
 import bcrypt from "bcrypt";
 import { createOtp, verifyOtp as verifyOtpService } from "./otp.service";
 import { sendOtpEmail } from "./email.service";
@@ -275,11 +276,67 @@ export async function updateSettlementScheduleService(data: {
   settlement_day?: number;
 }) {
   const { merchantId, settlement_schedule, settlement_day } = data;
+
+  const updateData: { settlement_schedule: string; settlement_day: number | null } = {
+    settlement_schedule,
+    // Clear settlement_day when switching to daily so batch logic stays consistent
+    settlement_day: settlement_schedule === "daily" ? null : (settlement_day ?? null),
+  };
+
   await prisma.merchant.update({
     where: { id: merchantId },
-    data: { settlement_schedule, settlement_day },
+    data: updateData,
   });
-  return { message: "Settlement schedule updated", settlement_schedule, settlement_day };
+  return { message: "Settlement schedule updated", settlement_schedule, settlement_day: updateData.settlement_day };
+}
+
+export async function updateBankAccountService(data: {
+  merchantId: string;
+  account_name?: string;
+  account_number?: string;
+  bank_name?: string;
+  bank_code?: string;
+  currency?: string;
+  country?: string;
+}) {
+  const { merchantId, ...updates } = data;
+
+  const existing = await prisma.bankAccount.findUnique({ where: { merchantId } });
+  if (!existing) throw { status: 404, message: 'No bank account found. Use POST /me/bank-account to create one.' };
+
+  // Cross-validate country/currency when both are present after merge
+  const mergedCountry = updates.country ?? existing.country;
+  const mergedCurrency = updates.currency ?? existing.currency;
+  const entry = countryMap.find((x) => x.countryCode === mergedCountry);
+  if (entry && entry.currencyCode !== mergedCurrency) {
+    throw {
+      status: 400,
+      message: `Currency ${mergedCurrency} is not valid for country ${mergedCountry}. Expected ${entry.currencyCode}.`,
+    };
+  }
+
+  const changedFields = Object.keys(updates).filter(
+    (k) => (updates as any)[k] !== undefined && (updates as any)[k] !== (existing as any)[k],
+  );
+
+  const bankAccount = await prisma.bankAccount.update({
+    where: { merchantId },
+    data: updates,
+  });
+
+  if (changedFields.length > 0) {
+    const oldValues: Record<string, any> = {};
+    const newValues: Record<string, any> = {};
+    for (const field of changedFields) {
+      oldValues[field] = (existing as any)[field];
+      newValues[field] = field === 'account_number'
+        ? `****${String((updates as any)[field]).slice(-4)}`
+        : (updates as any)[field];
+    }
+    logBankAccountChange({ merchantId, action: 'updated', changedFields, oldValues, newValues }).catch(() => {});
+  }
+
+  return { message: 'Bank account updated', bankAccount };
 }
 
 export async function addBankAccountService(data: {

--- a/fluxapay_backend/src/services/paymentMonitor.service.ts
+++ b/fluxapay_backend/src/services/paymentMonitor.service.ts
@@ -39,11 +39,8 @@ export async function runPaymentMonitorTick(): Promise<void> {
   const partialPaymentExpiry = new Date(now.getTime() - PARTIAL_PAYMENT_TIMEOUT);
   const stalePaymentExpiry = new Date(now.getTime() - STALE_PAYMENT_TIMEOUT);
 
-  const expired1 = await prisma.payment.updateMany({
-  // 1. Check for expired payments (pending or partially_paid)
+  // 1. Check for payments expired by their expiration date and fire webhooks
   const expiredPayments = await prisma.payment.findMany({
-  // 1. Check for expired payments by expiration date
-  await prisma.payment.updateMany({
     where: {
       status: { in: [PaymentStatus.PENDING, PaymentStatus.PARTIALLY_PAID] },
       expiration: { lte: now },
@@ -57,25 +54,19 @@ export async function runPaymentMonitorTick(): Promise<void> {
       expiration: true,
     },
   });
-  if (expired1.count > 0) trackPaymentExpired(expired1.count);
 
-  const expired2 = await prisma.payment.updateMany({
   for (const payment of expiredPayments) {
-    // Idempotent update: only transitions rows still in "pending" or "partially_paid"
+    // Idempotent update: only transitions rows still in pending/partially_paid
     const updated = await prisma.payment.updateMany({
       where: { id: payment.id, status: { in: [PaymentStatus.PENDING, PaymentStatus.PARTIALLY_PAID] } },
       data: { status: PaymentStatus.EXPIRED },
     });
 
-    if (updated.count === 0) {
-      // Already transitioned
-      continue;
-    }
+    if (updated.count === 0) continue;
 
-    // Emit internal event
+    trackPaymentExpired(1);
     eventBus.emit(AppEvents.PAYMENT_EXPIRED, { ...payment, status: PaymentStatus.EXPIRED });
 
-    // Fire webhook
     const eventId = `${payment.id}:expired`;
     try {
       await createAndDeliverWebhook(
@@ -101,8 +92,9 @@ export async function runPaymentMonitorTick(): Promise<void> {
       console.error(`[PaymentMonitor] Webhook failed for expired payment ${payment.id}:`, err);
     }
   }
-  // 2. Check for partial payments that have timed out
-  await prisma.payment.updateMany({
+
+  // 2. Expire partially-paid payments past the partial-payment timeout
+  const expired2 = await prisma.payment.updateMany({
     where: {
       status: PaymentStatus.PARTIALLY_PAID,
       last_seen_at: { lte: partialPaymentExpiry },
@@ -111,17 +103,18 @@ export async function runPaymentMonitorTick(): Promise<void> {
   });
   if (expired2.count > 0) trackPaymentExpired(expired2.count);
 
+  // 3. Expire stale pending payments that haven't seen activity
   const expired3 = await prisma.payment.updateMany({
     where: {
       status: { in: [PaymentStatus.PENDING, PaymentStatus.PARTIALLY_PAID] },
       last_seen_at: { lte: stalePaymentExpiry },
-      expiration: { gt: now }, // Not already expired by date
+      expiration: { gt: now },
     },
     data: { status: PaymentStatus.EXPIRED },
   });
   if (expired3.count > 0) trackPaymentExpired(expired3.count);
 
-  // 2. Monitor active payments
+  // 4. Monitor active payments for new on-chain transactions
   const payments = await prisma.payment.findMany({
     where: {
       status: { in: [PaymentStatus.PENDING, PaymentStatus.PARTIALLY_PAID] },
@@ -135,30 +128,26 @@ export async function runPaymentMonitorTick(): Promise<void> {
     if (!address) continue;
 
     try {
-      // Fetch total USDC balance for cumulative payment handling
+      // Fetch current USDC balance for cumulative payment handling
       const account = await getServer().loadAccount(address);
       const usdcBalanceRecord = account.balances.find((b: any) =>
         'asset_code' in b && b.asset_code === 'USDC' && b.asset_issuer === getUsdcAsset().issuer
       );
       const totalReceived = usdcBalanceRecord ? parseFloat(usdcBalanceRecord.balance) : 0;
 
-      // Build the payments query with cursor support to find new transactions
+      // Use cursor (last_paging_token) to only fetch transactions newer than last seen
       let paymentsQuery = getServer().payments()
         .forAccount(address)
         .order('desc')
         .limit(10);
 
-      // If we have a last paging token, start from there to only get new transactions
       if (payment.last_paging_token) {
         paymentsQuery = paymentsQuery.cursor(payment.last_paging_token);
       }
 
       const transactions = await paymentsQuery.call();
 
-      // Track the latest paging token to avoid re-processing
       let latestPagingToken = payment.last_paging_token;
-
-      // Process new transactions (if any) to find the latest valid payment
       let latestTxHash: string | undefined;
       let latestPayer: string | undefined;
 
@@ -171,6 +160,11 @@ export async function runPaymentMonitorTick(): Promise<void> {
           record.asset_type === 'credit_alphanum4' &&
           record.asset_code === 'USDC' &&
           record.asset_issuer === getUsdcAsset().issuer) {
+
+          // Dedupe: skip transactions already recorded on this payment
+          if (record.transaction_hash && record.transaction_hash === payment.transaction_hash) {
+            continue;
+          }
 
           if (!latestTxHash) {
             latestTxHash = record.transaction_hash;

--- a/fluxapay_backend/src/services/webhook.service.ts
+++ b/fluxapay_backend/src/services/webhook.service.ts
@@ -556,6 +556,23 @@ export function generateWebhookSignature(
   return crypto.createHmac("sha256", merchantSecret).update(signingString).digest("hex");
 }
 
+/**
+ * Replay protection: returns true only if the webhook timestamp falls within
+ * the allowed window. Default window is 5 minutes (300 000 ms).
+ *
+ * Merchants should call this before processing any incoming webhook to prevent
+ * replay attacks. Combine with event_id deduplication for full protection.
+ */
+export function verifyWebhookTimestamp(
+  timestamp: string,
+  windowMs: number = 5 * 60 * 1000,
+): boolean {
+  const webhookTime = new Date(timestamp).getTime();
+  if (isNaN(webhookTime)) return false;
+  const diff = Date.now() - webhookTime;
+  return diff >= 0 && diff <= windowMs;
+}
+
 // Helper function to generate test payload based on event type
 function generateTestPayload(
   eventType: WebhookEventType,
@@ -783,8 +800,14 @@ export async function createAndDeliverWebhook(
     return existing;
   }
 
-  // Embed event_id in the outgoing payload so merchants can deduplicate on their side.
-  const enrichedPayload = { event_id: resolvedEventId, ...payload };
+  // Embed event_id and timestamp in the outgoing payload so merchants can
+  // deduplicate and apply replay-protection on their side.
+  const deliveryTimestamp = new Date().toISOString();
+  const enrichedPayload = {
+    event_id: resolvedEventId,
+    timestamp: deliveryTimestamp,
+    ...payload,
+  };
 
   const webhookLog = await prisma.webhookLog.create({
     data: {


### PR DESCRIPTION

[Backend] Payment monitor: dedupe by tx hash and paging token Fixes #447

[Backend] Merchant: add endpoint to update bank account details Fixes #451

[Backend] Webhooks: implement replay protection window using timestamp Fixes #449

[Backend] Merchant: add endpoint to update settlement schedule Fixes #452