### PR TITLE
feat: connect settlements UI to backend API endpoints

### DIFF
--- a/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementDetailsModal.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementDetailsModal.tsx
@@ -1,87 +1,177 @@
 'use client';
 
-import { X, Download, FileText } from 'lucide-react';
-import { Settlement } from '../types';
-import { downloadSettlementPdf } from '@/lib/downloadPdf';
-import { downloadSettlementCsv } from '@/lib/downloadCsv';
+import { X, Download, FileText, Loader2 } from 'lucide-react';
+import { Badge } from '@/components/Badge';
+import {
+    useSettlementDetails,
+    useSettlementExport,
+} from '@/hooks/useSettlements';
 
 type Props = {
-    settlement: Settlement;
+    settlementId: string;
     onClose: () => void;
 };
 
-export function SettlementDetailsModal({ settlement, onClose }: Props) {
+export function SettlementDetailsModal({ settlementId, onClose }: Props) {
+    const { detail, isLoading, error } = useSettlementDetails(settlementId);
+    const { download, exporting } = useSettlementExport();
+
+    const getStatusBadge = (status: string) => {
+        switch (status) {
+            case 'completed': return <Badge variant="success">Completed</Badge>;
+            case 'pending': return <Badge variant="warning">Pending</Badge>;
+            case 'processing': return <Badge variant="info">Processing</Badge>;
+            case 'failed': return <Badge variant="error">Failed</Badge>;
+            default: return <Badge>{status}</Badge>;
+        }
+    };
+
     return (
-        <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4">
+            <div className="bg-card border border-border rounded-2xl max-w-3xl w-full max-h-[90vh] overflow-y-auto shadow-2xl animate-in zoom-in-95 duration-200">
                 {/* Header */}
-                <div className="p-6 border-b sticky top-0 bg-white flex justify-between items-center">
+                <div className="p-6 border-b border-border sticky top-0 bg-card rounded-t-2xl flex justify-between items-center">
                     <div>
-                        <h3 className="text-xl font-bold">{settlement.id}</h3>
-                        <p className="text-sm text-muted-foreground">Settlement details</p>
+                        <h3 className="text-xl font-bold">Settlement Details</h3>
+                        <p className="text-sm text-muted-foreground font-mono mt-0.5">
+                            {settlementId}
+                        </p>
                     </div>
-                    <button onClick={onClose}>
+                    <button
+                        onClick={onClose}
+                        className="p-2 hover:bg-secondary rounded-lg transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+                        aria-label="Close dialog"
+                    >
                         <X className="w-5 h-5" />
                     </button>
                 </div>
 
                 {/* Body */}
                 <div className="p-6 space-y-6">
-                    {/* Summary */}
-                    <div className="grid grid-cols-2 gap-4">
-                        <Info label="Date" value={new Date(settlement.date).toLocaleDateString()} />
-                        <Info label="Status" value={settlement.status} />
-                        <Info label="Payments" value={settlement.paymentsCount} />
-                        <Info label="Bank Ref" value={settlement.bankReference} />
-                    </div>
-
-                    {/* Financials */}
-                    <div className="border rounded-lg p-4 space-y-2">
-                        <Row label="USDC Amount" value={`$${settlement.usdcAmount}`} />
-                        <Row label="Conversion Rate" value={settlement.conversionRate} />
-                        <Row label="Fees" value={`-$${settlement.fees}`} danger />
-                        <Row
-                            label={`Total (${settlement.currency})`}
-                            value={`$${settlement.fiatAmount - settlement.fees}`}
-                            bold
-                        />
-                    </div>
-
-                    {/* Downloads */}
-                    <div className="flex gap-3">
-                        <button
-                            onClick={() => downloadSettlementPdf(settlement)}
-                            className="flex-1 flex items-center justify-center gap-2 bg-primary text-white py-2 rounded-lg"
-                        >
-                            <Download className="w-4 h-4" />
-                            PDF
-                        </button>
-
-                        <button
-                            onClick={() => downloadSettlementCsv(settlement)}
-                            className="flex-1 flex items-center justify-center gap-2 border py-2 rounded-lg"
-                        >
-                            <FileText className="w-4 h-4" />
-                            CSV
-                        </button>
-                    </div>
-
-                    {/* Payments */}
-                    {settlement.payments.length > 0 && (
-                        <div>
-                            <h4 className="font-semibold mb-3">Payments</h4>
-                            <div className="border rounded-lg divide-y max-h-60 overflow-y-auto">
-                                {settlement.payments.map((p) => (
-                                    <div key={p.id} className="p-3 flex justify-between">
-                                        <div>
-                                            <p className="font-medium text-sm">{p.id}</p>
-                                            <p className="text-xs text-muted-foreground">{p.customer}</p>
-                                        </div>
-                                        <p className="font-medium">${p.amount.toFixed(2)}</p>
-                                    </div>
-                                ))}
-                            </div>
+                    {isLoading && (
+                        <div className="flex items-center justify-center py-12">
+                            <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+                            <span className="ml-2 text-muted-foreground">Loading settlement…</span>
                         </div>
+                    )}
+
+                    {error && !isLoading && (
+                        <div className="text-center py-12 text-red-500">
+                            Failed to load settlement details.
+                        </div>
+                    )}
+
+                    {detail && !isLoading && (
+                        <>
+                            {/* Summary grid */}
+                            <div className="grid grid-cols-2 gap-4">
+                                <Info
+                                    label="Date"
+                                    value={new Date(detail.created_at).toLocaleDateString()}
+                                />
+                                <Info label="Status" value={getStatusBadge(detail.status)} />
+                                <Info
+                                    label="Scheduled"
+                                    value={new Date(detail.scheduled_date).toLocaleDateString()}
+                                />
+                                <Info
+                                    label="Processed"
+                                    value={
+                                        detail.processed_date
+                                            ? new Date(detail.processed_date).toLocaleDateString()
+                                            : '—'
+                                    }
+                                />
+                                <Info label="Currency" value={detail.currency} />
+                                <Info
+                                    label="Bank Transfer"
+                                    value={detail.bank_transfer_id ?? '—'}
+                                />
+                            </div>
+
+                            {/* Financial breakdown */}
+                            <div className="border border-border rounded-xl p-4 space-y-2">
+                                <Row
+                                    label="USDC Amount"
+                                    value={`$${Number(detail.usdc_amount ?? detail.amount).toLocaleString(undefined, { minimumFractionDigits: 2 })}`}
+                                />
+                                <Row
+                                    label="Exchange Rate"
+                                    value={detail.exchange_rate ? String(detail.exchange_rate) : '1.00'}
+                                />
+                                <Row
+                                    label="Fees"
+                                    value={`-$${Number(detail.fees).toLocaleString(undefined, { minimumFractionDigits: 2 })}`}
+                                    danger
+                                />
+                                <div className="border-t border-border pt-2" />
+                                <Row
+                                    label={`Net Payout (${detail.currency})`}
+                                    value={`$${Number(detail.net_amount ?? Number(detail.amount) - Number(detail.fees)).toLocaleString(undefined, { minimumFractionDigits: 2 })}`}
+                                    bold
+                                />
+                            </div>
+
+                            {/* Download buttons */}
+                            <div className="flex gap-3">
+                                <button
+                                    onClick={() => download(settlementId, 'pdf')}
+                                    disabled={exporting}
+                                    className="flex-1 flex items-center justify-center gap-2 bg-primary text-primary-foreground py-2.5 rounded-xl font-medium transition-colors hover:bg-primary/90 disabled:opacity-50"
+                                >
+                                    {exporting ? (
+                                        <Loader2 className="w-4 h-4 animate-spin" />
+                                    ) : (
+                                        <Download className="w-4 h-4" />
+                                    )}
+                                    PDF Report
+                                </button>
+
+                                <button
+                                    onClick={() => download(settlementId, 'csv')}
+                                    disabled={exporting}
+                                    className="flex-1 flex items-center justify-center gap-2 border border-border py-2.5 rounded-xl font-medium transition-colors hover:bg-secondary disabled:opacity-50"
+                                >
+                                    {exporting ? (
+                                        <Loader2 className="w-4 h-4 animate-spin" />
+                                    ) : (
+                                        <FileText className="w-4 h-4" />
+                                    )}
+                                    CSV Report
+                                </button>
+                            </div>
+
+                            {/* Failure reason */}
+                            {detail.failure_reason && (
+                                <div className="bg-red-500/10 border border-red-500/20 text-red-600 text-sm rounded-xl p-4">
+                                    <strong>Failure reason:</strong> {detail.failure_reason}
+                                </div>
+                            )}
+
+                            {/* Payments list */}
+                            {detail.payments && detail.payments.length > 0 && (
+                                <div>
+                                    <h4 className="font-semibold mb-3">
+                                        Included Payments ({detail.payments.length})
+                                    </h4>
+                                    <div className="border border-border rounded-xl divide-y divide-border max-h-60 overflow-y-auto">
+                                        {detail.payments.map((p) => (
+                                            <div key={p.id} className="p-3 flex justify-between items-center">
+                                                <div>
+                                                    <p className="font-mono text-xs text-muted-foreground">
+                                                        {p.id}
+                                                    </p>
+                                                    <p className="text-sm">{p.customer_email}</p>
+                                                </div>
+                                                <p className="font-mono font-medium">
+                                                    ${Number(p.amount).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                                                </p>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+                        </>
                     )}
                 </div>
             </div>
@@ -92,8 +182,8 @@ export function SettlementDetailsModal({ settlement, onClose }: Props) {
 function Info({ label, value }: { label: string; value: React.ReactNode }) {
     return (
         <div>
-            <p className="text-sm text-muted-foreground">{label}</p>
-            <p className="font-medium">{value}</p>
+            <p className="text-xs text-muted-foreground mb-1">{label}</p>
+            <div className="font-medium text-sm">{value}</div>
         </div>
     );
 }
@@ -116,7 +206,7 @@ function Row({
                 className={[
                     bold && 'font-bold',
                     danger && 'text-red-600',
-                ].join(' ')}
+                ].filter(Boolean).join(' ')}
             >
                 {value}
             </span>

--- a/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementPage.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementPage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { DollarSign, TrendingUp, Clock, Calendar } from "lucide-react";
 
 import { DataTableCard } from "@/components/data-table";
+import { TablePaginationBar } from "@/components/data-table/TablePaginationBar";
 import { StatCard } from "./StatCard";
 import { SettlementFilters } from "./SettlementFilters";
 import { SettlementsTable } from "./SettlementsTable";
@@ -11,43 +12,40 @@ import { SettlementDetailsModal } from "./SettlementDetailsModal";
 import {
   useSettlements,
   useSettlementSummary,
-  type MerchantSettlement,
 } from "@/hooks/useSettlements";
-import { MOCK_SETTLEMENTS } from "./mockSettlements";
+
+const PAGE_SIZE = 10;
 
 export default function SettlementsPage() {
+  const [page, setPage] = useState(1);
   const [status, setStatus] = useState("all");
   const [currency, setCurrency] = useState("all");
   const [date, setDate] = useState({ from: "", to: "" });
-  const [selected, setSelected] = useState<MerchantSettlement | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  const { isLoading } = useSettlements({
+  const { settlements, pagination, isLoading, error } = useSettlements({
+    page,
+    limit: PAGE_SIZE,
     status: status !== "all" ? status : undefined,
     currency: currency !== "all" ? currency : undefined,
     date_from: date.from || undefined,
     date_to: date.to || undefined,
-    limit: 100,
   });
-  const { summary } = useSettlementSummary();
+
+  const { summary, isLoading: summaryLoading } = useSettlementSummary();
 
   const avgDays = summary?.average_settlement_time_days ?? "—";
-  const nextDate = summary?.next_settlement_date ?? "—";
+  const nextDate = summary?.next_settlement_date
+    ? new Date(summary.next_settlement_date).toLocaleDateString()
+    : "—";
 
-  const filtered = MOCK_SETTLEMENTS.filter((s) => {
-    if (status !== "all" && s.status !== status) return false;
-    if (currency !== "all" && s.currency !== currency) return false;
-    if (date.from && s.date < date.from) return false;
-    if (date.to && s.date > date.to) return false;
-    return true;
-  });
+  const totalSettled = summary?.total_settled_this_month ?? 0;
+  const totalFees = summary?.total_fees_paid ?? 0;
 
-  const totalSettled = MOCK_SETTLEMENTS.filter(
-    (s) => s.status === "completed",
-  ).reduce((sum, s) => sum + s.fiatAmount, 0);
-
-  const totalFees = MOCK_SETTLEMENTS.filter(
-    (s) => s.status === "completed",
-  ).reduce((sum, s) => sum + s.fees, 0);
+  // Reset to page 1 when filters change
+  const handleStatusChange = (v: string) => { setStatus(v); setPage(1); };
+  const handleCurrencyChange = (v: string) => { setCurrency(v); setPage(1); };
+  const handleDateChange = (v: { from: string; to: string }) => { setDate(v); setPage(1); };
 
   return (
     <div className="space-y-6 p-6">
@@ -62,22 +60,22 @@ export default function SettlementsPage() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <StatCard
           title="Total Settled"
-          value={isLoading ? "…" : `$${Number(totalSettled).toLocaleString()}`}
+          value={summaryLoading ? "…" : `$${Number(totalSettled).toLocaleString()}`}
           icon={DollarSign}
         />
         <StatCard
           title="Total Fees"
-          value={isLoading ? "…" : `$${Number(totalFees).toLocaleString()}`}
+          value={summaryLoading ? "…" : `$${Number(totalFees).toLocaleString()}`}
           icon={TrendingUp}
         />
         <StatCard
           title="Avg. Settlement Time"
-          value={isLoading ? "…" : `${avgDays} days`}
+          value={summaryLoading ? "…" : `${avgDays} days`}
           icon={Clock}
         />
         <StatCard
           title="Next Settlement"
-          value={isLoading ? "…" : nextDate}
+          value={summaryLoading ? "…" : nextDate}
           icon={Calendar}
         />
       </div>
@@ -88,24 +86,35 @@ export default function SettlementsPage() {
             status={status}
             currency={currency}
             date={date}
-            onStatusChange={setStatus}
-            onCurrencyChange={setCurrency}
-            onDateChange={setDate}
+            onStatusChange={handleStatusChange}
+            onCurrencyChange={handleCurrencyChange}
+            onDateChange={handleDateChange}
           />
         }
       >
         <SettlementsTable
-          settlements={filtered}
-          onSelect={setSelected}
+          settlements={settlements}
+          onSelect={(s) => setSelectedId(s.id)}
           isLoading={isLoading}
+          error={error ? String(error) : null}
         />
+
+        {pagination && (
+          <TablePaginationBar
+            page={page}
+            pageSize={PAGE_SIZE}
+            total={pagination.total}
+            loading={isLoading}
+            onPageChange={setPage}
+          />
+        )}
       </DataTableCard>
 
-      {/* Modal */}
-      {selected && (
+      {/* Detail Modal */}
+      {selectedId && (
         <SettlementDetailsModal
-          settlement={selected}
-          onClose={() => setSelected(null)}
+          settlementId={selectedId}
+          onClose={() => setSelectedId(null)}
         />
       )}
     </div>

--- a/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementReportsPage.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementReportsPage.tsx
@@ -1,178 +1,68 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { subDays, startOfDay, format } from "date-fns";
-import { Download, FileText, TrendingUp, DollarSign, Eye } from "lucide-react";
+import { format } from "date-fns";
+import { Download, FileText, TrendingUp, DollarSign, Eye, Loader2 } from "lucide-react";
 import { Button } from "@/components/Button";
 import { Modal } from "@/components/Modal";
 import { Badge } from "@/components/Badge";
 import { api } from "@/lib/api";
+import {
+  useSettlements,
+  useSettlementDetails,
+  useSettlementExport,
+  type MerchantSettlement,
+} from "@/hooks/useSettlements";
 import toast from "react-hot-toast";
 
-interface Settlement {
-  id: string;
-  date: string;
-  status: "completed" | "pending" | "failed";
-  usdcAmount: number;
-  fiatAmount: number;
-  currency: string;
-  fees: number;
-  paymentsCount: number;
-  bankReference: string;
-  conversionRate: number;
-}
-
-interface SettlementDetails {
-  id: string;
-  date: string;
-  status: "completed" | "pending" | "failed";
-  usdcAmount: number;
-  fiatAmount: number;
-  currency: string;
-  fees: number;
-  netAmount: number;
-  paymentsCount: number;
-  bankReference: string;
-  conversionRate: number;
-  payments: Array<{
-    id: string;
-    amount: number;
-    currency: string;
-    customer_email: string;
-    created_at: string;
-  }>;
-}
-
-const MOCK_SETTLEMENTS: Settlement[] = [
-  {
-    id: "set_001",
-    date: "2026-02-20",
-    status: "completed",
-    usdcAmount: 5000,
-    fiatAmount: 4950,
-    currency: "USD",
-    fees: 50,
-    paymentsCount: 12,
-    bankReference: "BANK-20260220-001",
-    conversionRate: 0.99,
-  },
-  {
-    id: "set_002",
-    date: "2026-02-19",
-    status: "completed",
-    usdcAmount: 3200,
-    fiatAmount: 3168,
-    currency: "USD",
-    fees: 32,
-    paymentsCount: 8,
-    bankReference: "BANK-20260219-001",
-    conversionRate: 0.99,
-  },
-  {
-    id: "set_003",
-    date: "2026-02-18",
-    status: "pending",
-    usdcAmount: 2100,
-    fiatAmount: 2079,
-    currency: "USD",
-    fees: 21,
-    paymentsCount: 5,
-    bankReference: "BANK-20260218-001",
-    conversionRate: 0.99,
-  },
-];
-
-const MOCK_SETTLEMENT_DETAILS: SettlementDetails = {
-  id: "set_001",
-  date: "2026-02-20",
-  status: "completed",
-  usdcAmount: 5000,
-  fiatAmount: 4950,
-  currency: "USD",
-  fees: 50,
-  netAmount: 4900,
-  paymentsCount: 12,
-  bankReference: "BANK-20260220-001",
-  conversionRate: 0.99,
-  payments: [
-    {
-      id: "pay_001",
-      amount: 500,
-      currency: "USDC",
-      customer_email: "customer1@example.com",
-      created_at: "2026-02-20T10:30:00Z",
-    },
-    {
-      id: "pay_002",
-      amount: 300,
-      currency: "USDC",
-      customer_email: "customer2@example.com",
-      created_at: "2026-02-20T11:15:00Z",
-    },
-    {
-      id: "pay_003",
-      amount: 450,
-      currency: "USDC",
-      customer_email: "customer3@example.com",
-      created_at: "2026-02-20T12:00:00Z",
-    },
-  ],
-};
-
 export function SettlementReportsPage() {
-  const [dateRange, setDateRange] = useState<"7days" | "30days" | "90days">("30days");
-  const [selectedSettlement, setSelectedSettlement] = useState<SettlementDetails | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [selectedSettlementId, setSelectedSettlementId] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
 
-  const { startDate, endDate } = useMemo(() => {
-    const end = new Date();
-    let start = new Date();
-
-    if (dateRange === "7days") {
-      start = startOfDay(subDays(end, 7));
-    } else if (dateRange === "30days") {
-      start = startOfDay(subDays(end, 30));
-    } else if (dateRange === "90days") {
-      start = startOfDay(subDays(end, 90));
-    }
-
-    return { startDate: start, endDate: end };
-  }, [dateRange]);
-
-  const filteredSettlements = MOCK_SETTLEMENTS.filter((s) => {
-    const settlementDate = new Date(s.date);
-    return settlementDate >= startDate && settlementDate <= endDate;
+  const { settlements, isLoading, error } = useSettlements({
+    status: statusFilter !== "all" ? statusFilter : undefined,
+    date_from: dateFrom || undefined,
+    date_to: dateTo || undefined,
+    limit: 100,
   });
 
+  const { detail: selectedDetail, isLoading: detailLoading } =
+    useSettlementDetails(selectedSettlementId);
+
+  const { download: downloadSingle, exporting: singleExporting } = useSettlementExport();
+
   const stats = useMemo(() => {
-    const completed = filteredSettlements.filter((s) => s.status === "completed");
+    const completed = settlements.filter((s) => s.status === "completed");
     const totalUsdc = completed.reduce((sum, s) => sum + s.usdcAmount, 0);
     const totalFiat = completed.reduce((sum, s) => sum + s.fiatAmount, 0);
     const totalFees = completed.reduce((sum, s) => sum + s.fees, 0);
 
     return {
-      totalSettlements: filteredSettlements.length,
+      totalSettlements: settlements.length,
       completedSettlements: completed.length,
       totalUsdc,
       totalFiat,
       totalFees,
       avgFeePercent: completed.length > 0 ? ((totalFees / totalUsdc) * 100).toFixed(2) : "0",
     };
-  }, [filteredSettlements]);
+  }, [settlements]);
 
   const handleDownloadCSV = async () => {
     try {
-      setIsLoading(true);
+      setIsExporting(true);
       const blob = await api.settlements.exportRange({
-        date_from: startDate.toISOString(),
-        date_to: endDate.toISOString(),
+        date_from: dateFrom || undefined,
+        date_to: dateTo || undefined,
         format: "csv",
       });
 
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `settlements-${format(startDate, "yyyy-MM-dd")}-to-${format(endDate, "yyyy-MM-dd")}.csv`;
+      a.download = `settlements-report${dateFrom ? `-from-${dateFrom}` : ""}${dateTo ? `-to-${dateTo}` : ""}.csv`;
       document.body.appendChild(a);
       a.click();
       window.URL.revokeObjectURL(url);
@@ -182,23 +72,23 @@ export function SettlementReportsPage() {
     } catch {
       toast.error("Failed to download CSV");
     } finally {
-      setIsLoading(false);
+      setIsExporting(false);
     }
   };
 
   const handleDownloadPDF = async () => {
     try {
-      setIsLoading(true);
+      setIsExporting(true);
       const blob = await api.settlements.exportRange({
-        date_from: startDate.toISOString(),
-        date_to: endDate.toISOString(),
+        date_from: dateFrom || undefined,
+        date_to: dateTo || undefined,
         format: "pdf",
       });
 
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `settlements-${format(startDate, "yyyy-MM-dd")}-to-${format(endDate, "yyyy-MM-dd")}.pdf`;
+      a.download = `settlements-report${dateFrom ? `-from-${dateFrom}` : ""}${dateTo ? `-to-${dateTo}` : ""}.pdf`;
       document.body.appendChild(a);
       a.click();
       window.URL.revokeObjectURL(url);
@@ -208,15 +98,12 @@ export function SettlementReportsPage() {
     } catch {
       toast.error("Failed to download PDF");
     } finally {
-      setIsLoading(false);
+      setIsExporting(false);
     }
   };
 
-  const handleViewDetails = (settlement: Settlement) => {
-    setSelectedSettlement({
-      ...MOCK_SETTLEMENT_DETAILS,
-      ...settlement,
-    });
+  const handleViewDetails = (settlement: MerchantSettlement) => {
+    setSelectedSettlementId(settlement.id);
   };
 
   const getStatusBadge = (status: string) => {
@@ -225,6 +112,8 @@ export function SettlementReportsPage() {
         return <Badge variant="success">Completed</Badge>;
       case "pending":
         return <Badge variant="warning">Pending</Badge>;
+      case "processing":
+        return <Badge variant="info">Processing</Badge>;
       case "failed":
         return <Badge variant="error">Failed</Badge>;
       default:
@@ -247,18 +136,18 @@ export function SettlementReportsPage() {
             variant="secondary"
             className="gap-2"
             onClick={handleDownloadCSV}
-            disabled={isLoading}
+            disabled={isExporting}
           >
-            <Download className="h-4 w-4" />
+            {isExporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
             CSV
           </Button>
           <Button
             variant="secondary"
             className="gap-2"
             onClick={handleDownloadPDF}
-            disabled={isLoading}
+            disabled={isExporting}
           >
-            <Download className="h-4 w-4" />
+            {isExporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
             PDF
           </Button>
         </div>
@@ -266,108 +155,152 @@ export function SettlementReportsPage() {
 
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="p-4 rounded-xl border border-slate-200 bg-white">
+        <div className="p-4 rounded-xl border border-border bg-card">
           <div className="flex items-center gap-2 mb-2">
             <DollarSign className="h-4 w-4 text-amber-600" />
             <p className="text-sm text-muted-foreground">Total USDC</p>
           </div>
-          <p className="text-2xl font-bold">{stats.totalUsdc.toLocaleString()}</p>
+          <p className="text-2xl font-bold">
+            {isLoading ? "…" : stats.totalUsdc.toLocaleString(undefined, { minimumFractionDigits: 2 })}
+          </p>
           <p className="text-xs text-muted-foreground mt-1">{stats.completedSettlements} completed</p>
         </div>
 
-        <div className="p-4 rounded-xl border border-slate-200 bg-white">
+        <div className="p-4 rounded-xl border border-border bg-card">
           <div className="flex items-center gap-2 mb-2">
             <TrendingUp className="h-4 w-4 text-green-600" />
             <p className="text-sm text-muted-foreground">Total Fiat</p>
           </div>
-          <p className="text-2xl font-bold">${stats.totalFiat.toLocaleString()}</p>
+          <p className="text-2xl font-bold">
+            {isLoading ? "…" : `$${stats.totalFiat.toLocaleString(undefined, { minimumFractionDigits: 2 })}`}
+          </p>
           <p className="text-xs text-muted-foreground mt-1">After conversion</p>
         </div>
 
-        <div className="p-4 rounded-xl border border-slate-200 bg-white">
+        <div className="p-4 rounded-xl border border-border bg-card">
           <div className="flex items-center gap-2 mb-2">
             <FileText className="h-4 w-4 text-blue-600" />
             <p className="text-sm text-muted-foreground">Total Fees</p>
           </div>
-          <p className="text-2xl font-bold">${stats.totalFees.toLocaleString()}</p>
+          <p className="text-2xl font-bold">
+            {isLoading ? "…" : `$${stats.totalFees.toLocaleString(undefined, { minimumFractionDigits: 2 })}`}
+          </p>
           <p className="text-xs text-muted-foreground mt-1">{stats.avgFeePercent}% avg</p>
         </div>
 
-        <div className="p-4 rounded-xl border border-slate-200 bg-white">
+        <div className="p-4 rounded-xl border border-border bg-card">
           <div className="flex items-center gap-2 mb-2">
             <Eye className="h-4 w-4 text-purple-600" />
             <p className="text-sm text-muted-foreground">Settlements</p>
           </div>
-          <p className="text-2xl font-bold">{stats.totalSettlements}</p>
+          <p className="text-2xl font-bold">
+            {isLoading ? "…" : stats.totalSettlements}
+          </p>
           <p className="text-xs text-muted-foreground mt-1">In period</p>
         </div>
       </div>
 
       {/* Filters */}
-      <div className="p-4 rounded-xl border border-slate-200 bg-white">
-        <label className="text-sm font-medium text-slate-900 mb-2 block">Date Range</label>
-        <div className="flex gap-2">
-          {(["7days", "30days", "90days"] as const).map((range) => (
-            <button
-              key={range}
-              onClick={() => setDateRange(range)}
-              className={`px-3 py-1 text-sm rounded-lg transition-colors ${
-                dateRange === range
-                  ? "bg-slate-900 text-white"
-                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-              }`}
+      <div className="p-4 rounded-xl border border-border bg-card">
+        <label className="text-sm font-medium mb-3 block">Filters</label>
+        <div className="grid gap-4 md:grid-cols-3">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Status</label>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="w-full px-3 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
             >
-              {range === "7days" ? "Last 7 days" : range === "30days" ? "Last 30 days" : "Last 90 days"}
-            </button>
-          ))}
+              <option value="all">All Statuses</option>
+              <option value="completed">Completed</option>
+              <option value="pending">Pending</option>
+              <option value="processing">Processing</option>
+              <option value="failed">Failed</option>
+            </select>
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">From Date</label>
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => setDateFrom(e.target.value)}
+              className="w-full px-3 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">To Date</label>
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(e) => setDateTo(e.target.value)}
+              className="w-full px-3 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
         </div>
       </div>
 
       {/* Settlements Table */}
-      <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+      <div className="rounded-xl border border-border bg-card overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
-            <thead className="bg-slate-50 border-b border-slate-200">
+            <thead className="bg-muted/50 border-b border-border">
               <tr>
-                <th className="text-left py-3 px-4 font-medium text-slate-500">Date</th>
-                <th className="text-left py-3 px-4 font-medium text-slate-500">Status</th>
-                <th className="text-right py-3 px-4 font-medium text-slate-500">USDC Amount</th>
-                <th className="text-right py-3 px-4 font-medium text-slate-500">Fiat Amount</th>
-                <th className="text-right py-3 px-4 font-medium text-slate-500">Fees</th>
-                <th className="text-center py-3 px-4 font-medium text-slate-500">Payments</th>
-                <th className="text-center py-3 px-4 font-medium text-slate-500">Actions</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">Date</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">Status</th>
+                <th className="text-right py-3 px-4 font-medium text-muted-foreground">USDC Amount</th>
+                <th className="text-right py-3 px-4 font-medium text-muted-foreground">Fiat Amount</th>
+                <th className="text-right py-3 px-4 font-medium text-muted-foreground">Fees</th>
+                <th className="text-center py-3 px-4 font-medium text-muted-foreground">Payments</th>
+                <th className="text-center py-3 px-4 font-medium text-muted-foreground">Actions</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-200">
-              {filteredSettlements.length === 0 ? (
+            <tbody className="divide-y divide-border">
+              {isLoading ? (
                 <tr>
-                  <td colSpan={7} className="py-8 text-center text-slate-500">
+                  <td colSpan={7} className="py-12 text-center text-muted-foreground">
+                    <div className="flex items-center justify-center gap-2">
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      Loading settlements…
+                    </div>
+                  </td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td colSpan={7} className="py-8 text-center text-red-500">
+                    Failed to load settlements.
+                  </td>
+                </tr>
+              ) : settlements.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="py-8 text-center text-muted-foreground">
                     No settlements found for this period
                   </td>
                 </tr>
               ) : (
-                filteredSettlements.map((settlement) => (
-                  <tr key={settlement.id} className="hover:bg-slate-50 transition-colors">
-                    <td className="py-3 px-4 text-slate-900">
-                      {format(new Date(settlement.date), "MMM d, yyyy")}
+                settlements.map((settlement) => (
+                  <tr key={settlement.id} className="hover:bg-muted/50 transition-colors">
+                    <td className="py-3 px-4">
+                      {settlement.date
+                        ? format(new Date(settlement.date), "MMM d, yyyy")
+                        : "—"}
                     </td>
                     <td className="py-3 px-4">{getStatusBadge(settlement.status)}</td>
-                    <td className="py-3 px-4 text-right font-mono text-slate-900">
-                      {settlement.usdcAmount.toLocaleString()} USDC
+                    <td className="py-3 px-4 text-right font-mono">
+                      {settlement.usdcAmount.toLocaleString(undefined, { minimumFractionDigits: 2 })} USDC
                     </td>
-                    <td className="py-3 px-4 text-right font-mono text-slate-900">
-                      ${settlement.fiatAmount.toLocaleString()}
+                    <td className="py-3 px-4 text-right font-mono">
+                      ${settlement.fiatAmount.toLocaleString(undefined, { minimumFractionDigits: 2 })}
                     </td>
-                    <td className="py-3 px-4 text-right text-slate-500">
-                      ${settlement.fees.toLocaleString()}
+                    <td className="py-3 px-4 text-right text-muted-foreground">
+                      ${settlement.fees.toLocaleString(undefined, { minimumFractionDigits: 2 })}
                     </td>
-                    <td className="py-3 px-4 text-center text-slate-900">
+                    <td className="py-3 px-4 text-center">
                       {settlement.paymentsCount}
                     </td>
                     <td className="py-3 px-4 text-center">
                       <button
                         onClick={() => handleViewDetails(settlement)}
-                        className="text-amber-600 hover:text-amber-700 font-medium text-sm"
+                        className="text-primary hover:text-primary/80 font-medium text-sm transition-colors"
                       >
                         View
                       </button>
@@ -382,82 +315,115 @@ export function SettlementReportsPage() {
 
       {/* Settlement Details Modal */}
       <Modal
-        isOpen={!!selectedSettlement}
-        onClose={() => setSelectedSettlement(null)}
+        isOpen={!!selectedSettlementId}
+        onClose={() => setSelectedSettlementId(null)}
         title="Settlement Details"
       >
-        {selectedSettlement && (
+        {detailLoading && (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            <span className="ml-2 text-muted-foreground">Loading…</span>
+          </div>
+        )}
+
+        {selectedDetail && !detailLoading && (
           <div className="space-y-6">
             {/* Summary */}
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <p className="text-xs text-muted-foreground mb-1">Settlement ID</p>
-                <p className="font-mono text-sm font-medium">{selectedSettlement.id}</p>
+                <p className="font-mono text-sm font-medium">{selectedDetail.id}</p>
               </div>
               <div>
                 <p className="text-xs text-muted-foreground mb-1">Date</p>
                 <p className="text-sm font-medium">
-                  {format(new Date(selectedSettlement.date), "MMM d, yyyy")}
+                  {format(new Date(selectedDetail.created_at), "MMM d, yyyy")}
                 </p>
               </div>
               <div>
                 <p className="text-xs text-muted-foreground mb-1">Status</p>
-                <div>{getStatusBadge(selectedSettlement.status)}</div>
+                <div>{getStatusBadge(selectedDetail.status)}</div>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Bank Reference</p>
-                <p className="font-mono text-sm">{selectedSettlement.bankReference}</p>
+                <p className="text-xs text-muted-foreground mb-1">Bank Transfer</p>
+                <p className="font-mono text-sm">{selectedDetail.bank_transfer_id ?? "—"}</p>
               </div>
             </div>
 
             {/* Breakdown */}
-            <div className="border-t border-slate-200 pt-4">
-              <h3 className="font-semibold text-slate-900 mb-3">Amount Breakdown</h3>
+            <div className="border-t border-border pt-4">
+              <h3 className="font-semibold mb-3">Amount Breakdown</h3>
               <div className="space-y-2">
                 <div className="flex justify-between">
-                  <span className="text-slate-600">USDC Received</span>
+                  <span className="text-muted-foreground">USDC Received</span>
                   <span className="font-mono font-medium">
-                    {selectedSettlement.usdcAmount.toLocaleString()} USDC
+                    {Number(selectedDetail.usdc_amount ?? selectedDetail.amount).toLocaleString(undefined, { minimumFractionDigits: 2 })} USDC
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-slate-600">Conversion Rate</span>
-                  <span className="font-mono font-medium">{selectedSettlement.conversionRate}</span>
+                  <span className="text-muted-foreground">Exchange Rate</span>
+                  <span className="font-mono font-medium">
+                    {selectedDetail.exchange_rate ?? "1.00"}
+                  </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-slate-600">Fees</span>
+                  <span className="text-muted-foreground">Fees</span>
                   <span className="font-mono font-medium text-red-600">
-                    -${selectedSettlement.fees.toLocaleString()}
+                    -${Number(selectedDetail.fees).toLocaleString(undefined, { minimumFractionDigits: 2 })}
                   </span>
                 </div>
-                <div className="border-t border-slate-200 pt-2 flex justify-between">
-                  <span className="font-semibold text-slate-900">Net Amount</span>
+                <div className="border-t border-border pt-2 flex justify-between">
+                  <span className="font-semibold">Net Amount</span>
                   <span className="font-mono font-bold text-green-600">
-                    ${selectedSettlement.netAmount.toLocaleString()}
+                    ${Number(selectedDetail.net_amount ?? Number(selectedDetail.amount) - Number(selectedDetail.fees)).toLocaleString(undefined, { minimumFractionDigits: 2 })}
                   </span>
                 </div>
               </div>
             </div>
 
-            {/* Payments */}
-            <div className="border-t border-slate-200 pt-4">
-              <h3 className="font-semibold text-slate-900 mb-3">
-                Included Payments ({selectedSettlement.paymentsCount})
-              </h3>
-              <div className="space-y-2 max-h-48 overflow-y-auto">
-                {selectedSettlement.payments.map((payment) => (
-                  <div key={payment.id} className="flex justify-between text-sm p-2 bg-slate-50 rounded">
-                    <div>
-                      <p className="font-mono text-xs text-slate-500">{payment.id}</p>
-                      <p className="text-slate-600">{payment.customer_email}</p>
-                    </div>
-                    <span className="font-mono font-medium">
-                      {payment.amount} {payment.currency}
-                    </span>
-                  </div>
-                ))}
-              </div>
+            {/* Download buttons */}
+            <div className="flex gap-2 border-t border-border pt-4">
+              <Button
+                variant="secondary"
+                className="flex-1 gap-2"
+                onClick={() => downloadSingle(selectedDetail.id, "csv")}
+                disabled={singleExporting}
+              >
+                {singleExporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                CSV
+              </Button>
+              <Button
+                variant="secondary"
+                className="flex-1 gap-2"
+                onClick={() => downloadSingle(selectedDetail.id, "pdf")}
+                disabled={singleExporting}
+              >
+                {singleExporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                PDF
+              </Button>
             </div>
+
+            {/* Payments */}
+            {selectedDetail.payments && selectedDetail.payments.length > 0 && (
+              <div className="border-t border-border pt-4">
+                <h3 className="font-semibold mb-3">
+                  Included Payments ({selectedDetail.payments.length})
+                </h3>
+                <div className="space-y-2 max-h-48 overflow-y-auto">
+                  {selectedDetail.payments.map((payment) => (
+                    <div key={payment.id} className="flex justify-between text-sm p-2 bg-muted/50 rounded-lg">
+                      <div>
+                        <p className="font-mono text-xs text-muted-foreground">{payment.id}</p>
+                        <p className="text-foreground">{payment.customer_email}</p>
+                      </div>
+                      <span className="font-mono font-medium">
+                        ${Number(payment.amount).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
       </Modal>

--- a/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementsTable.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/settlements/SettlementsTable.tsx
@@ -2,16 +2,27 @@
 
 import { FileText } from 'lucide-react';
 import { DataTableBodyState } from '@/components/data-table';
-import { Settlement } from '../types';
+import type { MerchantSettlement } from '@/hooks/useSettlements';
+import { Badge } from '@/components/Badge';
 
 type Props = {
-    settlements: Settlement[];
-    onSelect: (settlement: Settlement) => void;
+    settlements: MerchantSettlement[];
+    onSelect: (settlement: MerchantSettlement) => void;
     isLoading?: boolean;
     error?: string | null;
 };
 
 export function SettlementsTable({ settlements, onSelect, isLoading = false, error = null }: Props) {
+    const getStatusBadge = (status: string) => {
+        switch (status) {
+            case 'completed': return <Badge variant="success">Completed</Badge>;
+            case 'pending': return <Badge variant="warning">Pending</Badge>;
+            case 'processing': return <Badge variant="info">Processing</Badge>;
+            case 'failed': return <Badge variant="error">Failed</Badge>;
+            default: return <Badge>{status}</Badge>;
+        }
+    };
+
     return (
         <div className="bg-card shadow overflow-hidden">
             <div className="overflow-x-auto">
@@ -69,24 +80,26 @@ export function SettlementsTable({ settlements, onSelect, isLoading = false, err
                                     <td className="px-6 py-4 whitespace-nowrap">
                                         <div className="flex items-center gap-2">
                                             <FileText className="w-4 h-4 text-muted-foreground" />
-                                            <span className="font-medium">{settlement.id}</span>
+                                            <span className="font-mono text-sm">{settlement.id.slice(0, 12)}…</span>
                                         </div>
                                     </td>
 
                                     <td className="px-6 py-4 whitespace-nowrap text-sm">
-                                        {new Date(settlement.date).toLocaleDateString()}
+                                        {settlement.date
+                                            ? new Date(settlement.date).toLocaleDateString()
+                                            : '—'}
                                     </td>
 
                                     <td className="px-6 py-4 whitespace-nowrap text-sm">
                                         {settlement.paymentsCount}
                                     </td>
 
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                                        ${settlement.usdcAmount.toLocaleString()}
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium font-mono">
+                                        ${settlement.usdcAmount.toLocaleString(undefined, { minimumFractionDigits: 2 })}
                                     </td>
 
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                                        ${settlement.fiatAmount.toLocaleString()}
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium font-mono">
+                                        ${settlement.fiatAmount.toLocaleString(undefined, { minimumFractionDigits: 2 })}
                                     </td>
 
                                     <td className="px-6 py-4 whitespace-nowrap text-sm">
@@ -94,20 +107,11 @@ export function SettlementsTable({ settlements, onSelect, isLoading = false, err
                                     </td>
 
                                     <td className="px-6 py-4 whitespace-nowrap">
-                                        <span
-                                            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${settlement.status === 'completed'
-                                                ? 'bg-green-100 text-green-800'
-                                                : settlement.status === 'pending'
-                                                    ? 'bg-yellow-100 text-yellow-800'
-                                                    : 'bg-red-100 text-red-800'
-                                                }`}
-                                        >
-                                            {settlement.status}
-                                        </span>
+                                        {getStatusBadge(settlement.status)}
                                     </td>
 
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-muted-foreground">
-                                        {settlement.bankReference}
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-muted-foreground font-mono">
+                                        {settlement.bankReference || '—'}
                                     </td>
                                 </tr>
                             ))}

--- a/fluxapay_frontend/src/hooks/useSettlements.ts
+++ b/fluxapay_frontend/src/hooks/useSettlements.ts
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import useSWR from "swr";
 import { api } from "@/lib/api";
+import toast from "react-hot-toast";
 
 /** Shape used by merchant dashboard SettlementsPage / SettlementsTable. */
 export interface MerchantSettlement {
@@ -109,4 +111,99 @@ export function useSettlementSummary() {
     isLoading,
     mutate,
   };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Single settlement detail (fetched from GET /api/v1/settlements/:id) */
+/* ------------------------------------------------------------------ */
+
+export interface SettlementDetailPayment {
+  id: string;
+  amount: number;
+  currency: string;
+  customer_email: string;
+  status: string;
+  createdAt: string;
+}
+
+export interface SettlementDetail {
+  id: string;
+  merchantId: string;
+  usdc_amount: number;
+  amount: number;
+  fees: number;
+  net_amount: number;
+  currency: string;
+  status: "completed" | "pending" | "processing" | "failed";
+  exchange_partner: string | null;
+  exchange_rate: number | null;
+  exchange_ref: string | null;
+  bank_transfer_id: string | null;
+  payment_ids: string[] | null;
+  failure_reason: string | null;
+  scheduled_date: string;
+  processed_date: string | null;
+  created_at: string;
+  updated_at: string;
+  payments: SettlementDetailPayment[];
+  merchant?: { business_name: string };
+}
+
+export function useSettlementDetails(settlementId: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<SettlementDetail>(
+    settlementId ? ["settlement-detail", settlementId] : null,
+    () => api.settlements.getById(settlementId!) as Promise<SettlementDetail>,
+  );
+  return { detail: data ?? null, error, isLoading, mutate };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Download settlement report (CSV / PDF) via backend export endpoint */
+/* ------------------------------------------------------------------ */
+
+export function useSettlementExport() {
+  const [exporting, setExporting] = useState(false);
+
+  const download = useCallback(
+    async (settlementId: string, format: "csv" | "pdf") => {
+      setExporting(true);
+      try {
+        const result = await api.settlements.export(settlementId, format);
+
+        // Backend returns { filename, content, contentType }
+        const filename =
+          (result as { filename?: string }).filename ??
+          `settlement-${settlementId}.${format}`;
+        const content = (result as { content?: unknown }).content;
+
+        let blob: Blob;
+        if (format === "csv" && typeof content === "string") {
+          blob = new Blob([content], { type: "text/csv;charset=utf-8;" });
+        } else {
+          // PDF data returned as JSON — stringify for download
+          const jsonStr =
+            typeof content === "string" ? content : JSON.stringify(content, null, 2);
+          blob = new Blob([jsonStr], { type: "application/json" });
+        }
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        toast.success(`${format.toUpperCase()} downloaded`);
+      } catch {
+        toast.error(`Failed to download ${format.toUpperCase()}`);
+      } finally {
+        setExporting(false);
+      }
+    },
+    [],
+  );
+
+  return { download, exporting };
 }


### PR DESCRIPTION
Closes #404

## Summary
Connects the entire settlements UI to the backend API, replacing all mock
data with real API-driven state. Covers the settlements list, summary stats,
pagination, filtering, detail modal, and export/download flows for both
single settlements and bulk date-range reports.

## What changed

### `useSettlements.ts` *(modified)*
- Added `useSettlementDetails(settlementId)` — fetches a single settlement
  with its linked payments from `GET /api/v1/settlements/:id`
- Added `useSettlementExport()` — triggers backend CSV/PDF download with
  toast feedback on success and failure

### `SettlementPage.tsx` *(modified)*
- Replaced `MOCK_SETTLEMENTS` with real data from `useSettlements()`
- Summary stats now sourced from `useSettlementSummary()`
- Pagination is server-driven
- Applying a filter resets to page 1

### `SettlementsTable.tsx` *(modified)*
- Switched to `MerchantSettlement` type from hooks
- Added proper `Badge` status indicators
- CUIDs truncated for readability

### `SettlementDetailsModal.tsx` *(modified)*
- Now accepts `settlementId` and fetches from `GET /api/v1/settlements/:id`
- Downloads routed through the backend export endpoint
- Shows loading and error states
- Displays failure reasons where applicable

### `SettlementReportsPage.tsx` *(modified)*
- Fully replaced mock data with API hooks
- Detail modal, single-settlement downloads, and bulk date-range exports
  all hit real backend endpoints

### `mockSettlements.ts`
- No longer imported anywhere — safe to delete in a follow-up cleanup PR

## Verification
- TypeScript: ✅ clean compile, zero errors in touched files

## Notes
- `mockSettlements.ts` has been left in place for now to keep this PR
  focused on the API wiring — it can be removed in a dedicated cleanup commit