### PR TITLE
feat:[Frontend] Auth: centralize token storage and API error handling

### DIFF
--- a/fluxapay_frontend/src/app/admin/AdminGuard.tsx
+++ b/fluxapay_frontend/src/app/admin/AdminGuard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Loader2, ShieldOff } from 'lucide-react';
+import { isAuthenticated, isAdmin } from '@/lib/auth';
 
 const ADMIN_ENABLED = process.env.NEXT_PUBLIC_ADMIN_ENABLED === 'true';
 
@@ -22,10 +23,7 @@ export default function AdminGuard({ children }: { children: React.ReactNode }) 
             return;
         }
 
-        const token = localStorage.getItem('token');
-        const isAdmin = localStorage.getItem('isAdmin');
-
-        if (!token || isAdmin !== 'true') {
+        if (!isAuthenticated() || !isAdmin()) {
             router.replace('/login');
             return;
         }

--- a/fluxapay_frontend/src/app/providers.tsx
+++ b/fluxapay_frontend/src/app/providers.tsx
@@ -4,11 +4,17 @@ import { ReactNode } from "react";
 import { SWRConfig } from "swr";
 import GlobalErrorBoundary from "@/components/GlobalErrorBoundary";
 import { toastApiError } from "@/lib/toastApiError";
+import { handleAuthError } from "@/lib/auth";
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <GlobalErrorBoundary>
-      <SWRConfig value={{ onError: (error) => toastApiError(error) }}>
+      <SWRConfig value={{
+        onError: (error) => {
+          handleAuthError(error);
+          toastApiError(error);
+        }
+      }}>
         {children}
       </SWRConfig>
     </GlobalErrorBoundary>

--- a/fluxapay_frontend/src/features/settings/components/SettingsPage.tsx
+++ b/fluxapay_frontend/src/features/settings/components/SettingsPage.tsx
@@ -6,6 +6,7 @@ import Input from "@/components/Input";
 import { Button } from "@/components/Button";
 import { Modal } from "@/components/Modal";
 import { api, ApiError, clearToken } from "@/lib/api";
+import { logout, getToken } from "@/lib/auth";
 import { DOCS_URLS } from "@/lib/docs";
 import { isValidHttpsWebhookUrl } from "@/lib/webhookUrl";
 
@@ -83,11 +84,10 @@ export default function SettingsPage() {
   const getSessionNote = () => {
     if (typeof window === "undefined") return "Current session active";
 
-    const token =
-      localStorage.getItem("token") || sessionStorage.getItem("token");
-    if (!token) return "No active session token found";
-
     try {
+      const token = getToken();
+      if (!token) return "No active session token found";
+
       const payloadSegment = token.split(".")[1];
       if (!payloadSegment) return "Current session active";
 
@@ -304,8 +304,7 @@ export default function SettingsPage() {
 
   const handleSignOutCurrentSession = () => {
     setIsSigningOut(true);
-    clearToken();
-    window.location.href = "/login";
+    logout();
   };
 
   const handleSignOutAllSessions = async () => {
@@ -318,8 +317,7 @@ export default function SettingsPage() {
         console.error("Logout-all request failed:", error);
       }
     } finally {
-      clearToken();
-      window.location.href = "/login";
+      logout();
     }
   };
 

--- a/fluxapay_frontend/src/lib/api.ts
+++ b/fluxapay_frontend/src/lib/api.ts
@@ -1,5 +1,10 @@
 // API Client for FluxaPay Backend
+import { getToken, storeToken, clearToken } from "./auth";
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+// Re-export auth functions for backward compatibility
+export { getToken, storeToken, clearToken } from "./auth";
 
 export interface AuthSignupRequest {
   business_name: string;
@@ -57,37 +62,8 @@ class ApiError extends Error {
   }
 }
 
-function getToken(): string {
-  // Check localStorage first (persistent), then sessionStorage (session-only)
-  const token = localStorage.getItem("token") ?? sessionStorage.getItem("token");
-  if (!token) {
-    throw new ApiError(401, "No authentication token found");
-  }
-  return token;
-}
-
-/** Persist auth token.
- *  keepLoggedIn=true  → localStorage  (survives browser close, expires with JWT TTL ~30 days)
- *  keepLoggedIn=false → sessionStorage (cleared when the tab/browser is closed)
- */
-export function storeToken(token: string, keepLoggedIn = false): void {
-  if (keepLoggedIn) {
-    localStorage.setItem("token", token);
-    sessionStorage.removeItem("token"); // clear any leftover session token
-  } else {
-    sessionStorage.setItem("token", token);
-    localStorage.removeItem("token"); // ensure no persistent copy remains
-  }
-}
-
-/** Remove auth token from all storage locations. */
-export function clearToken(): void {
-  localStorage.removeItem("token");
-  sessionStorage.removeItem("token");
-}
-
 async function fetchWithAuth(endpoint: string, options: RequestInit = {}) {
-  const token = localStorage.getItem("token") ?? sessionStorage.getItem("token");
+  const token = getToken();
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",

--- a/fluxapay_frontend/src/lib/auth.ts
+++ b/fluxapay_frontend/src/lib/auth.ts
@@ -1,0 +1,95 @@
+// Centralized Auth Module for FluxaPay Frontend
+// Handles token storage, retrieval, and global auth state management
+
+import { ApiError } from "./api";
+
+/**
+ * Storage keys for auth tokens
+ */
+const TOKEN_KEY = "token";
+const ADMIN_KEY = "isAdmin";
+
+/**
+ * Get the current auth token from storage.
+ * Checks localStorage first (persistent), then sessionStorage (session-only).
+ * @throws {ApiError} If no token is found
+ */
+export function getToken(): string {
+  const token = localStorage.getItem(TOKEN_KEY) ?? sessionStorage.getItem(TOKEN_KEY);
+  if (!token) {
+    throw new ApiError(401, "No authentication token found");
+  }
+  return token;
+}
+
+/**
+ * Check if user is authenticated (has a valid token)
+ */
+export function isAuthenticated(): boolean {
+  try {
+    getToken();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if current user is admin
+ */
+export function isAdmin(): boolean {
+  return localStorage.getItem(ADMIN_KEY) === "true";
+}
+
+/**
+ * Store auth token in appropriate storage based on persistence preference.
+ * @param token - The JWT token to store
+ * @param keepLoggedIn - If true, stores in localStorage (persistent); otherwise sessionStorage
+ */
+export function storeToken(token: string, keepLoggedIn = false): void {
+  if (keepLoggedIn) {
+    localStorage.setItem(TOKEN_KEY, token);
+    sessionStorage.removeItem(TOKEN_KEY); // Clear any leftover session token
+  } else {
+    sessionStorage.setItem(TOKEN_KEY, token);
+    localStorage.removeItem(TOKEN_KEY); // Ensure no persistent copy remains
+  }
+}
+
+/**
+ * Set admin status
+ */
+export function setAdminStatus(isAdmin: boolean): void {
+  if (isAdmin) {
+    localStorage.setItem(ADMIN_KEY, "true");
+  } else {
+    localStorage.removeItem(ADMIN_KEY);
+  }
+}
+
+/**
+ * Clear all auth-related data from storage
+ */
+export function clearAuth(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  sessionStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(ADMIN_KEY);
+}
+
+/**
+ * Logout user by clearing auth data and redirecting to login
+ */
+export function logout(): void {
+  clearAuth();
+  // Use window.location for full page reload to clear any cached state
+  window.location.href = "/login";
+}
+
+/**
+ * Handle authentication errors (401/403) by logging out user
+ */
+export function handleAuthError(error: unknown): void {
+  if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+    logout();
+  }
+}

--- a/fluxapay_frontend/src/lib/toastApiError.tsx
+++ b/fluxapay_frontend/src/lib/toastApiError.tsx
@@ -25,6 +25,11 @@ function isRetryable(error: unknown): boolean {
 }
 
 export function toastApiError(error: unknown): void {
+  // Don't show toast for auth errors (401/403) as they're handled globally with logout
+  if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+    return;
+  }
+
   try {
     toast.error(resolveMessage(error));
   } catch {


### PR DESCRIPTION
- Created centralized auth module (lib/auth.ts) for token management
- Moved token storage logic from api.ts to auth.ts
- Updated all components to use centralized auth functions
- Added global 401/403 error handling with auto-logout in providers.tsx
- Modified toastApiError to skip toasts for auth errors
- Updated AdminGuard, SettingsPage, and other components to use new auth API
closes #429 