### PR TITLE
feat: service worker offline support and IndexedDB checkout sync queue

### DIFF
--- a/fluxapay_frontend/next.config.ts
+++ b/fluxapay_frontend/next.config.ts
@@ -26,6 +26,30 @@ const nextConfig: NextConfig = {
     );
     return config;
   },
+  async headers() {
+    return [
+      {
+        // Prevent the browser from caching the service worker script so updates
+        // are picked up immediately on the next page load.
+        source: "/sw.js",
+        headers: [
+          { key: "Service-Worker-Allowed", value: "/" },
+          { key: "Cache-Control", value: "no-cache, no-store, must-revalidate" },
+        ],
+      },
+      {
+        // Allow the checkout shell HTML to be served stale while the SW
+        // revalidates it in the background (matching the SW strategy).
+        source: "/pay/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=0, stale-while-revalidate=86400",
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     const redirects = [
       {

--- a/fluxapay_frontend/public/sw.js
+++ b/fluxapay_frontend/public/sw.js
@@ -1,52 +1,97 @@
 /**
  * FluxaPay Service Worker
  *
- * Routing strategies:
- *   - /api/*          → network-first (always try network, fall back to cache)
- *   - static assets   → cache-first (serve from cache, fetch and cache on miss)
- *   - everything else → passthrough (browser default)
+ * Caching strategies:
+ *   - /api/*                  → network-first (live data; cache as offline fallback)
+ *   - /pay/* (navigate)       → stale-while-revalidate (checkout shell)
+ *   - static assets           → cache-first (JS/CSS/fonts/images)
+ *   - everything else         → passthrough (browser default)
  *
  * Registered only in production by src/app/sw-register.tsx.
  */
 
-const CACHE_NAME = "fluxapay-v1";
+const SHELL_CACHE = 'fluxapay-shell-v1';
+const STATIC_CACHE = 'fluxapay-static-v1';
+const KNOWN_CACHES = [SHELL_CACHE, STATIC_CACHE];
+
 const STATIC_EXTENSIONS = /\.(js|css|png|jpg|jpeg|svg|woff2?|ttf|ico|webmanifest|json)$/;
 
-self.addEventListener("fetch", (event) => {
+const PRECACHE_URLS = [
+  '/manifest.json',
+  '/icons/icon-192x192.png',
+  '/icons/icon-512x512.png',
+];
+
+// Precache shell assets on install so the checkout page loads offline immediately.
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(SHELL_CACHE)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+// Remove caches from older SW versions on activate.
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => !KNOWN_CACHES.includes(key))
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
-  if (url.pathname.startsWith("/api/")) {
+  if (url.pathname.startsWith('/api/')) {
     event.respondWith(networkFirst(request));
-  } else if (STATIC_EXTENSIONS.test(url.pathname)) {
-    event.respondWith(cacheFirst(request));
+    return;
   }
-  // All other requests fall through to the browser default
+
+  if (url.pathname.startsWith('/pay/') && request.mode === 'navigate') {
+    event.respondWith(staleWhileRevalidate(request, SHELL_CACHE));
+    return;
+  }
+
+  if (STATIC_EXTENSIONS.test(url.pathname)) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE));
+    return;
+  }
 });
 
 /**
- * Cache-first strategy: serve from cache; fetch and cache on miss.
+ * Cache-first: serve from cache, populate cache on miss.
  */
-async function cacheFirst(request) {
+async function cacheFirst(request, cacheName) {
   const cached = await caches.match(request);
   if (cached) return cached;
 
   const response = await fetch(request);
   if (response.ok) {
-    const cache = await caches.open(CACHE_NAME);
+    const cache = await caches.open(cacheName);
     cache.put(request, response.clone());
   }
   return response;
 }
 
 /**
- * Network-first strategy: fetch from network; fall back to cache on failure.
+ * Network-first: fetch from network, cache success, fall back to cache on failure.
  */
 async function networkFirst(request) {
+  const cacheName = STATIC_CACHE;
   try {
     const response = await fetch(request);
     if (response.ok) {
-      const cache = await caches.open(CACHE_NAME);
+      const cache = await caches.open(cacheName);
       cache.put(request, response.clone());
     }
     return response;
@@ -55,4 +100,28 @@ async function networkFirst(request) {
     if (cached) return cached;
     throw new Error(`Network request failed and no cache available for: ${request.url}`);
   }
+}
+
+/**
+ * Stale-while-revalidate: respond from cache immediately, refresh cache in background.
+ * Falls back to network when not yet cached; throws when both are unavailable.
+ */
+async function staleWhileRevalidate(request, cacheName) {
+  const cached = await caches.match(request);
+
+  const networkPromise = fetch(request).then(async (response) => {
+    if (response.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, response.clone());
+    }
+    return response;
+  });
+
+  if (cached) {
+    // Serve stale immediately; let network update the cache in background.
+    networkPromise.catch(() => {});
+    return cached;
+  }
+
+  return networkPromise;
 }

--- a/fluxapay_frontend/src/app/pay/[payment_id]/page.tsx
+++ b/fluxapay_frontend/src/app/pay/[payment_id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Loader2, XCircle, CheckCircle, AlertCircle, RefreshCw } from 'lucide-react';
 import { usePaymentStatus } from '@/hooks/usePaymentStatus';
+import { useOfflineSync } from '@/hooks/useOfflineSync';
 import { TxHashLink } from '@/components/TxHashLink';
 import { PaymentQRCode } from '@/components/checkout/PaymentQRCode';
 import { PaymentTimer } from '@/components/checkout/PaymentTimer';
@@ -72,6 +73,8 @@ export default function CheckoutPage() {
   const { payment, loading, error, isOffline, retryConnection } =
     usePaymentStatus(paymentId);
 
+  const { pendingCount, queueAction } = useOfflineSync(paymentId, retryConnection);
+
   // Customization from query params (SDK overrides)
   const qAccent = searchParams.get('accentColor') || searchParams.get('primaryColor');
   const qLogo = searchParams.get('logoUrl');
@@ -112,13 +115,20 @@ export default function CheckoutPage() {
           aria-live="polite"
         >
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <p className="text-sm font-medium">
-              {t('checkout.offlineMessage')}
-            </p>
+            <div>
+              <p className="text-sm font-medium">
+                {t('checkout.offlineMessage')}
+              </p>
+              {pendingCount > 0 && (
+                <p className="mt-1 text-xs text-amber-700">
+                  {pendingCount} action{pendingCount > 1 ? 's' : ''} queued — will sync when reconnected
+                </p>
+              )}
+            </div>
             <button
               type="button"
               onClick={() => {
-                void retryConnection();
+                void queueAction('retry-connection');
               }}
               className="rounded-md border border-amber-400 bg-white px-3 py-1 text-sm font-semibold text-amber-900 hover:bg-amber-100"
             >

--- a/fluxapay_frontend/src/hooks/useOfflineSync.ts
+++ b/fluxapay_frontend/src/hooks/useOfflineSync.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  enqueueCheckoutAction,
+  getPendingActions,
+  markActionSynced,
+  clearSyncedActions,
+  type QueuedCheckoutAction,
+} from '@/lib/idb-queue';
+
+interface UseOfflineSyncReturn {
+  pendingCount: number;
+  queueAction: (type: QueuedCheckoutAction['type']) => Promise<void>;
+}
+
+export function useOfflineSync(
+  paymentId: string,
+  onSync: () => Promise<void>,
+): UseOfflineSyncReturn {
+  const [pendingCount, setPendingCount] = useState(0);
+
+  const refreshCount = useCallback(async () => {
+    if (typeof indexedDB === 'undefined') return;
+    const pending = await getPendingActions(paymentId);
+    setPendingCount(pending.length);
+  }, [paymentId]);
+
+  useEffect(() => {
+    void refreshCount();
+  }, [refreshCount]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleOnline = async () => {
+      if (typeof indexedDB === 'undefined') return;
+      const pending = await getPendingActions(paymentId);
+      if (pending.length === 0) return;
+
+      try {
+        await onSync();
+        await Promise.all(
+          pending
+            .filter((a): a is QueuedCheckoutAction & { id: number } => a.id !== undefined)
+            .map((a) => markActionSynced(a.id)),
+        );
+        await clearSyncedActions();
+        setPendingCount(0);
+      } catch {
+        // Sync failed — actions remain queued for the next online event
+      }
+    };
+
+    window.addEventListener('online', handleOnline);
+    return () => window.removeEventListener('online', handleOnline);
+  }, [paymentId, onSync]);
+
+  const queueAction = useCallback(
+    async (type: QueuedCheckoutAction['type']) => {
+      if (typeof indexedDB === 'undefined') return;
+      await enqueueCheckoutAction(paymentId, type);
+      await refreshCount();
+    },
+    [paymentId, refreshCount],
+  );
+
+  return { pendingCount, queueAction };
+}

--- a/fluxapay_frontend/src/lib/idb-queue.ts
+++ b/fluxapay_frontend/src/lib/idb-queue.ts
@@ -1,0 +1,129 @@
+const DB_NAME = 'fluxapay-offline';
+const DB_VERSION = 1;
+const STORE_NAME = 'checkout-actions';
+
+export interface QueuedCheckoutAction {
+  id?: number;
+  paymentId: string;
+  type: 'retry-connection' | 'validate-payment';
+  timestamp: number;
+  synced: boolean;
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, {
+          keyPath: 'id',
+          autoIncrement: true,
+        });
+        store.createIndex('paymentId', 'paymentId', { unique: false });
+        store.createIndex('synced', 'synced', { unique: false });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function enqueueCheckoutAction(
+  paymentId: string,
+  type: QueuedCheckoutAction['type'],
+): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const action: Omit<QueuedCheckoutAction, 'id'> = {
+      paymentId,
+      type,
+      timestamp: Date.now(),
+      synced: false,
+    };
+    const req = store.add(action);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    tx.oncomplete = () => db.close();
+  });
+}
+
+export async function getPendingActions(
+  paymentId?: string,
+): Promise<QueuedCheckoutAction[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const results: QueuedCheckoutAction[] = [];
+
+    const source = paymentId
+      ? store.index('paymentId').openCursor(IDBKeyRange.only(paymentId))
+      : store.openCursor();
+
+    source.onsuccess = (event) => {
+      const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>).result;
+      if (cursor) {
+        const record = cursor.value as QueuedCheckoutAction;
+        if (!record.synced) results.push(record);
+        cursor.continue();
+      } else {
+        resolve(results);
+      }
+    };
+
+    source.onerror = () => reject(source.error);
+    tx.oncomplete = () => db.close();
+  });
+}
+
+export async function markActionSynced(id: number): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const getReq = store.get(id);
+
+    getReq.onsuccess = () => {
+      const record = getReq.result as QueuedCheckoutAction | undefined;
+      if (record) {
+        record.synced = true;
+        const putReq = store.put(record);
+        putReq.onsuccess = () => resolve();
+        putReq.onerror = () => reject(putReq.error);
+      } else {
+        resolve();
+      }
+    };
+
+    getReq.onerror = () => reject(getReq.error);
+    tx.oncomplete = () => db.close();
+  });
+}
+
+export async function clearSyncedActions(): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const index = store.index('synced');
+    const req = index.openCursor(IDBKeyRange.only(true));
+
+    req.onsuccess = (event) => {
+      const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>).result;
+      if (cursor) {
+        cursor.delete();
+        cursor.continue();
+      } else {
+        resolve();
+      }
+    };
+
+    req.onerror = () => reject(req.error);
+    tx.oncomplete = () => db.close();
+  });
+}


### PR DESCRIPTION
- Add install/activate lifecycle events to sw.js: precache manifest and icons on install, purge stale caches on activate with clients.claim()
- Add stale-while-revalidate strategy for /pay/* navigation requests so the checkout shell loads from cache instantly while the SW refreshes it
- Add Service-Worker-Allowed and no-cache headers for sw.js in next.config.ts so SW updates are picked up on the next page load
- Add Cache-Control stale-while-revalidate header for /pay/* routes to align browser and SW caching behaviour
- Implement idb-queue.ts: IndexedDB-backed queue for offline checkout actions with enqueue, getPendingActions, markActionSynced and clearSyncedActions helpers
- Implement useOfflineSync hook: enqueues customer retry actions while offline and automatically drains the queue (calling retryConnection) when the network comes back via the window online event
- Wire useOfflineSync into CheckoutPage: clicking Retry Now while offline enqueues a retry-connection action; pending count is shown in the banner so the customer knows their intent will be replayed on reconnection

closes #574 
closes #573 