### PR TITLE
feat: add interactive api sandbox to developer docs

### DIFF
--- a/fluxapay_frontend/src/app/[locale]/docs/api-reference/page.tsx
+++ b/fluxapay_frontend/src/app/[locale]/docs/api-reference/page.tsx
@@ -3,6 +3,8 @@ import { DocsLayout } from "@/components/docs/DocsLayout";
 import { EndpointCard } from "@/components/docs/EndpointCard";
 import { EditOnGitHub } from "@/components/docs/EditOnGitHub";
 import { generatePageMetadata } from "@/lib/seo";
+import { ApiSandboxProvider } from "@/components/docs/ApiSandboxContext";
+import { ApiKeyInput } from "@/components/docs/ApiKeyInput";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
@@ -474,8 +476,9 @@ refunds = response.json()`,
 export default function LocalizedApiReferencePage() {
   return (
     <DocsLayout>
-      <div className="space-y-8">
-        {/* Header */}
+      <ApiSandboxProvider>
+        <div className="space-y-8">
+          {/* Header */}
         <div>
           <p className="text-sm font-semibold text-zinc-500 uppercase tracking-wider mb-2">
             API Reference
@@ -488,6 +491,8 @@ export default function LocalizedApiReferencePage() {
             via Bearer token unless otherwise noted.
           </p>
         </div>
+
+        <ApiKeyInput />
 
         {/* Base URL */}
         <div className="p-4 rounded-xl border border-slate-200 bg-slate-50">
@@ -612,6 +617,7 @@ export default function LocalizedApiReferencePage() {
           <EditOnGitHub filePath="fluxapay_frontend/src/app/[locale]/docs/api-reference/page.tsx" />
         </div>
       </div>
+      </ApiSandboxProvider>
     </DocsLayout>
   );
 }

--- a/fluxapay_frontend/src/components/docs/ApiKeyInput.tsx
+++ b/fluxapay_frontend/src/components/docs/ApiKeyInput.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useState } from "react";
+import { useApiSandbox } from "./ApiSandboxContext";
+import { Key, Eye, EyeOff, CheckCircle2 } from "lucide-react";
+
+export function ApiKeyInput() {
+  const { apiKey, setApiKey } = useApiSandbox();
+  const [showKey, setShowKey] = useState(false);
+  const [inputValue, setInputValue] = useState(apiKey);
+  const [isSaved, setIsSaved] = useState(false);
+
+  const handleSave = () => {
+    setApiKey(inputValue);
+    setIsSaved(true);
+    setTimeout(() => setIsSaved(false), 2000);
+  };
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-4 mb-8">
+      <div className="flex items-center gap-2 mb-2">
+        <Key className="w-5 h-5 text-slate-500" />
+        <h3 className="text-sm font-semibold text-slate-900">Sandbox API Key</h3>
+      </div>
+      <p className="text-sm text-slate-500 mb-4">
+        Enter your sandbox API key to enable the interactive API runner. Your key is stored locally and never sent anywhere except the FluxaPay sandbox server.
+      </p>
+      
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1 max-w-md">
+          <input
+            type={showKey ? "text" : "password"}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder="sk_test_..."
+            className="w-full pl-3 pr-10 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm font-mono text-slate-700"
+          />
+          <button
+            type="button"
+            onClick={() => setShowKey(!showKey)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 focus:outline-none"
+          >
+            {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+          </button>
+        </div>
+        <button
+          onClick={handleSave}
+          className="px-4 py-2 bg-slate-900 hover:bg-slate-800 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2"
+        >
+          {isSaved ? (
+            <>
+              <CheckCircle2 className="w-4 h-4 text-green-400" />
+              Saved
+            </>
+          ) : (
+            "Save Key"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/fluxapay_frontend/src/components/docs/ApiSandboxContext.tsx
+++ b/fluxapay_frontend/src/components/docs/ApiSandboxContext.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+interface ApiSandboxContextType {
+  apiKey: string;
+  setApiKey: (key: string) => void;
+}
+
+const ApiSandboxContext = createContext<ApiSandboxContextType | undefined>(undefined);
+
+export function ApiSandboxProvider({ children }: { children: ReactNode }) {
+  const [apiKey, setApiKey] = useState("");
+
+  return (
+    <ApiSandboxContext.Provider value={{ apiKey, setApiKey }}>
+      {children}
+    </ApiSandboxContext.Provider>
+  );
+}
+
+export function useApiSandbox() {
+  const context = useContext(ApiSandboxContext);
+  if (context === undefined) {
+    throw new Error("useApiSandbox must be used within an ApiSandboxProvider");
+  }
+  return context;
+}

--- a/fluxapay_frontend/src/components/docs/EndpointCard.tsx
+++ b/fluxapay_frontend/src/components/docs/EndpointCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Play, Loader2 } from "lucide-react";
 import { CodeBlock } from "./CodeBlock";
+import { useApiSandbox } from "./ApiSandboxContext";
 
 interface EndpointParam {
   name: string;
@@ -46,7 +47,68 @@ export function EndpointCard({
   pythonExample,
 }: EndpointCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const [activeTab, setActiveTab] = useState<"ts" | "python">("ts");
+  const [activeTab, setActiveTab] = useState<"ts" | "python" | "sandbox">("ts");
+
+  const { apiKey } = useApiSandbox();
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [sandboxLoading, setSandboxLoading] = useState(false);
+  const [sandboxResponse, setSandboxResponse] = useState<{status: number, data: any} | null>(null);
+  const [sandboxError, setSandboxError] = useState<string | null>(null);
+
+  const handleSandboxSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!apiKey) {
+      setSandboxError("Please enter your Sandbox API Key at the top of the page.");
+      return;
+    }
+    
+    setSandboxLoading(true);
+    setSandboxError(null);
+    setSandboxResponse(null);
+
+    try {
+      let finalPath = path;
+      const queryParams = new URLSearchParams();
+      let body: Record<string, any> | undefined = undefined;
+
+      params.forEach((param) => {
+        const val = formValues[param.name];
+        if (val) {
+          if (finalPath.includes(`:${param.name}`)) {
+            finalPath = finalPath.replace(`:${param.name}`, val);
+          } else if (method === "GET" || method === "DELETE") {
+            queryParams.append(param.name, val);
+          } else {
+            if (!body) body = {};
+            if (param.type === "number" || param.type === "integer") body[param.name] = Number(val);
+            else if (param.type === "boolean") body[param.name] = val === "true";
+            else if (param.type === "object" || param.type === "array") {
+              try { body[param.name] = JSON.parse(val); } catch (err) { body[param.name] = val; }
+            }
+            else body[param.name] = val;
+          }
+        }
+      });
+
+      const url = `https://sandbox-api.fluxapay.com${finalPath}${queryParams.toString() ? `?${queryParams.toString()}` : ""}`;
+
+      const res = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${apiKey}`
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      const data = await res.json().catch(() => null);
+      setSandboxResponse({ status: res.status, data });
+    } catch (err: any) {
+      setSandboxError(err.message || "Failed to execute request");
+    } finally {
+      setSandboxLoading(false);
+    }
+  };
 
   return (
     <div className="border border-slate-200 rounded-xl bg-white overflow-hidden mb-4">
@@ -133,12 +195,86 @@ export function EndpointCard({
                 >
                   Python
                 </button>
+                <button
+                  onClick={() => setActiveTab("sandbox")}
+                  className={`px-3 py-1 text-sm rounded-lg transition-colors flex items-center gap-1.5 ${
+                    activeTab === "sandbox"
+                      ? "bg-blue-600 text-white"
+                      : "bg-blue-50 text-blue-600 hover:bg-blue-100"
+                  }`}
+                >
+                  <Play className="w-3.5 h-3.5" />
+                  Sandbox
+                </button>
               </div>
               {activeTab === "ts" && tsExample && (
                 <CodeBlock code={tsExample} language="typescript" title="TypeScript Example" />
               )}
               {activeTab === "python" && pythonExample && (
                 <CodeBlock code={pythonExample} language="python" title="Python Example" />
+              )}
+              {activeTab === "sandbox" && (
+                <div className="mt-4 p-4 bg-slate-50 border border-slate-200 rounded-xl">
+                  <h4 className="text-sm font-semibold text-slate-900 mb-4">Interactive Sandbox</h4>
+                  <form onSubmit={handleSandboxSubmit} className="space-y-4">
+                    {params.length > 0 ? (
+                      <div className="space-y-3">
+                        {params.map(param => (
+                          <div key={param.name}>
+                            <label className="block text-xs font-medium text-slate-700 mb-1">
+                              {param.name} {param.required && <span className="text-red-500">*</span>}
+                              <span className="text-slate-400 ml-2 font-normal">({param.type})</span>
+                            </label>
+                            <input
+                              type="text"
+                              required={param.required}
+                              value={formValues[param.name] || ""}
+                              onChange={e => setFormValues({...formValues, [param.name]: e.target.value})}
+                              placeholder={param.description}
+                              className="w-full px-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-slate-500 mb-4">No parameters required for this endpoint.</p>
+                    )}
+                    
+                    <button
+                      type="submit"
+                      disabled={sandboxLoading}
+                      className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50"
+                    >
+                      {sandboxLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+                      Try it out
+                    </button>
+                  </form>
+
+                  {sandboxError && (
+                    <div className="mt-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg">
+                      {sandboxError}
+                    </div>
+                  )}
+
+                  {sandboxResponse && (
+                    <div className="mt-4">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-xs font-semibold text-slate-500 uppercase">Response</span>
+                        <span className={`text-xs font-mono font-medium px-2 py-0.5 rounded ${
+                          sandboxResponse.status >= 200 && sandboxResponse.status < 300
+                            ? "bg-green-100 text-green-700"
+                            : "bg-red-100 text-red-700"
+                        }`}>
+                          {sandboxResponse.status}
+                        </span>
+                      </div>
+                      <CodeBlock 
+                        code={sandboxResponse.data ? JSON.stringify(sandboxResponse.data, null, 2) : "No content"} 
+                        language="json" 
+                      />
+                    </div>
+                  )}
+                </div>
               )}
             </div>
           )}


### PR DESCRIPTION
I integrated an interactive API sandbox component into the developer documentation portal, allowing users to securely input their API keys and test FluxaPay endpoints directly from the browser.

closes #572