### PR TITLE
[frontend] Checkout Page: Show Live USDC/Fiat Equivalent Below Payment Amount

### DIFF
--- a/fluxapay_frontend/src/app/pay/[payment_id]/page.tsx
+++ b/fluxapay_frontend/src/app/pay/[payment_id]/page.tsx
@@ -13,6 +13,7 @@ import { PaymentTimer } from '@/components/checkout/PaymentTimer';
 import { PaymentStatus } from '@/components/checkout/PaymentStatus';
 import { StellarPayButton } from '@/components/checkout/StellarPayButton';
 import { BrowserWalletButtons } from '@/components/checkout/BrowserWalletButtons';
+import { FxRateBadge } from '@/components/checkout/FxRateBadge';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import {
   CheckoutBrandingShell,
@@ -411,6 +412,7 @@ export default function CheckoutPage() {
               <p className="text-3xl font-bold text-gray-900 sm:text-4xl">
                 {payment.amount} {payment.currency}
               </p>
+              <FxRateBadge currency="USD" className="mt-1 justify-center" />
               {payment.description && (
                 <p className="mt-2 text-sm text-gray-500">{payment.description}</p>
               )}

--- a/fluxapay_frontend/src/components/checkout/FxRateBadge.tsx
+++ b/fluxapay_frontend/src/components/checkout/FxRateBadge.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useFxRate } from "@/hooks/useFxRate";
+import { Loader2, AlertCircle } from "lucide-react";
+
+interface FxRateBadgeProps {
+  currency?: string;
+  className?: string;
+}
+
+export function FxRateBadge({ currency = "USD", className = "" }: FxRateBadgeProps) {
+  const { rate, timestamp, error, isLoading } = useFxRate(currency);
+
+  const lastUpdated = timestamp
+    ? new Date(timestamp).toLocaleTimeString()
+    : null;
+
+  const isStale =
+    timestamp && Date.now() - new Date(timestamp).getTime() > 5 * 60 * 1000;
+
+  if (isLoading) {
+    return (
+      <div className={`flex items-center gap-1.5 text-xs text-gray-400 ${className}`}>
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        <span>Loading rate…</span>
+      </div>
+    );
+  }
+
+  if (error || !rate) {
+    return (
+      <div className={`flex items-center gap-1.5 text-xs text-amber-600 ${className}`}>
+        <AlertCircle className="h-3 w-3" aria-hidden="true" />
+        <span>Rate unavailable</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`text-xs text-gray-500 ${className}`}>
+      <span>
+        1 USDC = {rate} {currency}
+      </span>
+      {lastUpdated && (
+        <span className="ml-2 text-gray-400">
+          • Updated {lastUpdated}
+          {isStale && " • Stale"}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/fluxapay_frontend/src/hooks/useFxRate.ts
+++ b/fluxapay_frontend/src/hooks/useFxRate.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import useSWR from "swr";
+import { api } from "@/lib/api";
+
+export interface FxRateResponse {
+  rate: number;
+  currency: string;
+  timestamp: string;
+}
+
+export function useFxRate(currency: string) {
+  const { data, error, isLoading } = useSWR<FxRateResponse>(
+    currency ? ["fx-rate", currency] : null,
+    () => api.fx.getRate(currency) as Promise<FxRateResponse>,
+    { refreshInterval: 60_000 },
+  );
+
+  return {
+    rate: data?.rate ?? null,
+    currency: data?.currency ?? currency,
+    timestamp: data?.timestamp ?? null,
+    error,
+    isLoading,
+  };
+}

--- a/fluxapay_frontend/src/lib/api.ts
+++ b/fluxapay_frontend/src/lib/api.ts
@@ -352,6 +352,19 @@ export const api = {
       }),
   },
 
+  // FX rates
+  fx: {
+    getRate: (currency: string) =>
+      fetch(`${API_BASE_URL}/api/v1/fx-rates?currency=${encodeURIComponent(currency)}`).then(
+        async (res) => {
+          if (!res.ok) {
+            throw new ApiError(res.status, "Failed to fetch FX rate");
+          }
+          return res.json();
+        },
+      ),
+  },
+
   // Health / readiness
   health: {
     check: () => fetch(`${API_BASE_URL}/health`),


### PR DESCRIPTION
## Summary

Implements live FX rate widget on the checkout page per issue #690.

### Changes
- Add `api.fx.getRate(currency)` to API client
- Create `useFxRate(currency)` SWR hook with 60s auto-refresh
- Build `FxRateBadge` component (loading/error/stale states)
- Embed in checkout page below payment amount

Closes #690