### PR TITLE
Feature/fluxapay sentry csp sidebar txhashlink

### DIFF
--- a/fluxapay_frontend/next.config.ts
+++ b/fluxapay_frontend/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import path from "node:path";
+import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   env: {
@@ -112,4 +113,12 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  silent: true,
+  widenClientFileUpload: true,
+  tunnelRoute: "/monitoring",
+  hideSourceMaps: true,
+});

--- a/fluxapay_frontend/next.config.ts
+++ b/fluxapay_frontend/next.config.ts
@@ -27,10 +27,26 @@ const nextConfig: NextConfig = {
     return config;
   },
   async headers() {
+    // CSP trusted script origins:
+    // - 'self': app's own scripts from the origin
+    // - https://albedo.link: Albedo wallet provider
+    // - Freighter is injected via browser extension (no explicit CSP needed for extension content)
+    // - Nonces can be added at runtime for inline scripts if needed
+    const cspHeader = [
+      "default-src 'self'",
+      "script-src 'self' https://albedo.link",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "font-src 'self' data:",
+      "connect-src 'self'",
+      "frame-ancestors 'none'",
+      process.env.NEXT_PUBLIC_CSP_REPORT_URI ? `report-uri ${process.env.NEXT_PUBLIC_CSP_REPORT_URI}` : "",
+    ]
+      .filter(Boolean)
+      .join("; ");
+
     return [
       {
-        // Prevent the browser from caching the service worker script so updates
-        // are picked up immediately on the next page load.
         source: "/sw.js",
         headers: [
           { key: "Service-Worker-Allowed", value: "/" },
@@ -38,14 +54,27 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Allow the checkout shell HTML to be served stale while the SW
-        // revalidates it in the background (matching the SW strategy).
         source: "/pay/:path*",
         headers: [
           {
             key: "Cache-Control",
             value: "public, max-age=0, stale-while-revalidate=86400",
           },
+          { key: "Content-Security-Policy", value: cspHeader },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-no-referrer" },
+          { key: "Permissions-Policy", value: "geolocation=(), microphone=(), camera=()" },
+        ],
+      },
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Content-Security-Policy", value: cspHeader },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-no-referrer" },
+          { key: "Permissions-Policy", value: "geolocation=(), microphone=(), camera=()" },
         ],
       },
     ];

--- a/fluxapay_frontend/package.json
+++ b/fluxapay_frontend/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-select": "^2.2.6",
+    "@sentry/nextjs": "^8.14.0",
     "autoprefixer": "^10.4.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/fluxapay_frontend/sentry.client.config.ts
+++ b/fluxapay_frontend/sentry.client.config.ts
@@ -1,0 +1,16 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  debug: process.env.NODE_ENV !== "production",
+  integrations: [
+    new Sentry.Replay({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});

--- a/fluxapay_frontend/sentry.server.config.ts
+++ b/fluxapay_frontend/sentry.server.config.ts
@@ -1,0 +1,8 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  debug: process.env.NODE_ENV !== "production",
+});

--- a/fluxapay_frontend/src/app/error.tsx
+++ b/fluxapay_frontend/src/app/error.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
 
 /**
  * app/error.tsx — root-level error boundary.
@@ -14,6 +16,9 @@ export default function RootError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
   return (
     <div className="hero">
       <div className="py-8 h-screen flex flex-col relative overflow-hidden">

--- a/fluxapay_frontend/src/components/GlobalErrorBoundary.tsx
+++ b/fluxapay_frontend/src/components/GlobalErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import * as Sentry from "@sentry/nextjs";
 
 interface Props {
   children: ReactNode;
@@ -22,6 +23,7 @@ class GlobalErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error(error, info);
+    Sentry.captureException(error, { contexts: { react: info } });
   }
 
   handleReset(): void {

--- a/fluxapay_frontend/src/components/TxHashLink.tsx
+++ b/fluxapay_frontend/src/components/TxHashLink.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ExternalLink, Copy } from 'lucide-react';
-import { getStellarExpertTxUrl, shouldOpenInNewTab } from '@/lib/stellar';
+import { getStellarExpertTxUrl, shouldOpenInNewTab, type StellarNetwork } from '@/lib/stellar';
 
 interface TxHashLinkProps {
   /** Full transaction hash from the Stellar network. */
@@ -11,6 +11,11 @@ interface TxHashLinkProps {
    * When provided, this takes precedence over the auto-generated URL.
    */
   stellarExpertUrl?: string;
+  /**
+   * Optional network override ("testnet" or "public").
+   * When provided, overrides NEXT_PUBLIC_STELLAR_NETWORK env var.
+   */
+  network?: StellarNetwork;
   /**
    * How many leading characters of the hash to show.
    * @default 8
@@ -38,13 +43,14 @@ interface TxHashLinkProps {
 export function TxHashLink({
   txHash,
   stellarExpertUrl,
+  network,
   truncateStart = 8,
   truncateEnd = 4,
   className = '',
   showCopy = false,
   label,
 }: TxHashLinkProps) {
-  const href = stellarExpertUrl || getStellarExpertTxUrl(txHash);
+  const href = stellarExpertUrl || getStellarExpertTxUrl(txHash, network);
   const openInNewTab = shouldOpenInNewTab();
 
   const displayed =

--- a/fluxapay_frontend/src/features/dashboard/components/Sidebar.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/Sidebar.tsx
@@ -87,7 +87,7 @@ export function Sidebar({ className, isOpen, onClose }: SidebarProps) {
         {navItems.map((item) => {
           const isActive = item.href === "/dashboard"
             ? pathname === "/dashboard"
-            : pathname.startsWith(item.href);
+            : pathname === item.href || pathname.startsWith(item.href + "/");
 
           return (
             <Link

--- a/fluxapay_frontend/src/features/dashboard/components/__tests__/Sidebar.test.tsx
+++ b/fluxapay_frontend/src/features/dashboard/components/__tests__/Sidebar.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Sidebar } from "../Sidebar";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+import { usePathname } from "next/navigation";
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const getAriaCurrentElements = () => {
+    return screen.queryAllByRole("link", { current: "page" });
+  };
+
+  it("renders navigation items", () => {
+    (usePathname as any).mockReturnValue("/dashboard");
+
+    render(<Sidebar />);
+
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByText("Payments")).toBeInTheDocument();
+    expect(screen.getByText("Invoices")).toBeInTheDocument();
+  });
+
+  it("marks Overview as active for /dashboard", () => {
+    (usePathname as any).mockReturnValue("/dashboard");
+
+    render(<Sidebar />);
+
+    const overviewLink = screen.getByText("Overview").closest("a");
+    expect(overviewLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks Payments as active for /dashboard/payments", () => {
+    (usePathname as any).mockReturnValue("/dashboard/payments");
+
+    render(<Sidebar />);
+
+    const paymentsLink = screen.getByText("Payments").closest("a");
+    expect(paymentsLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks Payments as active for nested route /dashboard/payments/[id]", () => {
+    (usePathname as any).mockReturnValue("/dashboard/payments/123");
+
+    render(<Sidebar />);
+
+    const paymentsLink = screen.getByText("Payments").closest("a");
+    expect(paymentsLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks Invoices as active for nested route /dashboard/invoices/[id]", () => {
+    (usePathname as any).mockReturnValue("/dashboard/invoices/456");
+
+    render(<Sidebar />);
+
+    const invoicesLink = screen.getByText("Invoices").closest("a");
+    expect(invoicesLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("does not mark similar-prefix route as active", () => {
+    (usePathname as any).mockReturnValue("/dashboard/payments-custom");
+
+    render(<Sidebar />);
+
+    const paymentsLink = screen.getByText("Payments").closest("a");
+    expect(paymentsLink).not.toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks only one item as active per route", () => {
+    (usePathname as any).mockReturnValue("/dashboard/payments/789");
+
+    render(<Sidebar />);
+
+    const activeLinks = getAriaCurrentElements();
+    expect(activeLinks).toHaveLength(1);
+    expect(activeLinks[0]).toHaveTextContent("Payments");
+  });
+
+  it("uses aria-label for semantic navigation", () => {
+    (usePathname as any).mockReturnValue("/dashboard");
+
+    const { container } = render(<Sidebar />);
+
+    const nav = container.querySelector("nav");
+    expect(nav).toHaveAttribute("aria-label", "Main navigation");
+  });
+
+  it("uses aria-current=page for active links (screen reader announcement)", () => {
+    (usePathname as any).mockReturnValue("/dashboard/refunds");
+
+    render(<Sidebar />);
+
+    const refundsLink = screen.getByText("Refunds").closest("a");
+    expect(refundsLink).toHaveAttribute("aria-current", "page");
+
+    // Verify other links don't have aria-current
+    const paymentsLink = screen.getByText("Payments").closest("a");
+    expect(paymentsLink).not.toHaveAttribute("aria-current");
+  });
+
+  it("updates active state when pathname changes", () => {
+    const { rerender } = render(<Sidebar />);
+
+    (usePathname as any).mockReturnValue("/dashboard/payments");
+    rerender(<Sidebar />);
+
+    let paymentsLink = screen.getByText("Payments").closest("a");
+    expect(paymentsLink).toHaveAttribute("aria-current", "page");
+
+    (usePathname as any).mockReturnValue("/dashboard/invoices");
+    rerender(<Sidebar />);
+
+    paymentsLink = screen.getByText("Payments").closest("a");
+    expect(paymentsLink).not.toHaveAttribute("aria-current", "page");
+
+    const invoicesLink = screen.getByText("Invoices").closest("a");
+    expect(invoicesLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("handles deeply nested routes", () => {
+    (usePathname as any).mockReturnValue(
+      "/dashboard/payments/detail/123/refund/456"
+    );
+
+    render(<Sidebar />);
+
+    const paymentsLink = screen.getByText("Payments").closest("a");
+    expect(paymentsLink).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/fluxapay_frontend/src/lib/__tests__/stellar.test.ts
+++ b/fluxapay_frontend/src/lib/__tests__/stellar.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getStellarNetwork,
+  getStellarExpertTxUrl,
+  shouldOpenInNewTab,
+} from "@/lib/stellar";
+
+describe("stellar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+    delete process.env.NEXT_PUBLIC_STELLAR_EXPLORER_NEW_TAB;
+  });
+
+  describe("getStellarNetwork", () => {
+    it("defaults to testnet when env var not set", () => {
+      expect(getStellarNetwork()).toBe("testnet");
+    });
+
+    it("returns public when NEXT_PUBLIC_STELLAR_NETWORK is public", () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = "public";
+      expect(getStellarNetwork()).toBe("public");
+    });
+
+    it("returns testnet when NEXT_PUBLIC_STELLAR_NETWORK is testnet", () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = "testnet";
+      expect(getStellarNetwork()).toBe("testnet");
+    });
+
+    it("defaults to testnet for invalid env values", () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = "invalid";
+      expect(getStellarNetwork()).toBe("testnet");
+    });
+
+    it("is case-insensitive", () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = "PUBLIC";
+      expect(getStellarNetwork()).toBe("public");
+    });
+  });
+
+  describe("getStellarExpertTxUrl", () => {
+    it("builds testnet URL when network defaults to testnet", () => {
+      const url = getStellarExpertTxUrl("abc123");
+      expect(url).toBe("https://stellar.expert/explorer/testnet/tx/abc123");
+    });
+
+    it("builds public URL when NEXT_PUBLIC_STELLAR_NETWORK is public", () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = "public";
+      const url = getStellarExpertTxUrl("abc123");
+      expect(url).toBe("https://stellar.expert/explorer/public/tx/abc123");
+    });
+
+    it("uses network prop to override env default", () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = "testnet";
+      const url = getStellarExpertTxUrl("abc123", "public");
+      expect(url).toBe("https://stellar.expert/explorer/public/tx/abc123");
+    });
+
+    it("respects network prop even when env is public", () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = "public";
+      const url = getStellarExpertTxUrl("abc123", "testnet");
+      expect(url).toBe("https://stellar.expert/explorer/testnet/tx/abc123");
+    });
+
+    it("handles long transaction hashes", () => {
+      const longHash =
+        "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+      const url = getStellarExpertTxUrl(longHash, "public");
+      expect(url).toContain(longHash);
+      expect(url).toBe(
+        `https://stellar.expert/explorer/public/tx/${longHash}`
+      );
+    });
+  });
+
+  describe("shouldOpenInNewTab", () => {
+    it("defaults to true when env var not set", () => {
+      expect(shouldOpenInNewTab()).toBe(true);
+    });
+
+    it("defaults to true when env var is empty string", () => {
+      process.env.NEXT_PUBLIC_STELLAR_EXPLORER_NEW_TAB = "";
+      expect(shouldOpenInNewTab()).toBe(true);
+    });
+
+    it("returns false when env var is false", () => {
+      process.env.NEXT_PUBLIC_STELLAR_EXPLORER_NEW_TAB = "false";
+      expect(shouldOpenInNewTab()).toBe(false);
+    });
+
+    it("returns false when env var is FALSE (case-insensitive)", () => {
+      process.env.NEXT_PUBLIC_STELLAR_EXPLORER_NEW_TAB = "FALSE";
+      expect(shouldOpenInNewTab()).toBe(false);
+    });
+
+    it("returns true for any truthy value", () => {
+      process.env.NEXT_PUBLIC_STELLAR_EXPLORER_NEW_TAB = "true";
+      expect(shouldOpenInNewTab()).toBe(true);
+
+      process.env.NEXT_PUBLIC_STELLAR_EXPLORER_NEW_TAB = "1";
+      expect(shouldOpenInNewTab()).toBe(true);
+    });
+  });
+});

--- a/fluxapay_frontend/src/lib/sentry-utils.ts
+++ b/fluxapay_frontend/src/lib/sentry-utils.ts
@@ -1,0 +1,13 @@
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Set merchant context in Sentry.
+ * Only includes merchant ID (no PII).
+ */
+export function setSentryMerchantContext(merchantId: string | null): void {
+  if (merchantId) {
+    Sentry.setUser({ id: merchantId });
+  } else {
+    Sentry.setUser(null);
+  }
+}

--- a/fluxapay_frontend/src/lib/stellar.ts
+++ b/fluxapay_frontend/src/lib/stellar.ts
@@ -31,11 +31,16 @@ export function shouldOpenInNewTab(): boolean {
 /**
  * Build a Stellar Expert transaction URL for the given hash.
  *
+ * @param txHash - The transaction hash
+ * @param network - Optional network override. If not provided, uses NEXT_PUBLIC_STELLAR_NETWORK
+ *
  * @example
  * getStellarExpertTxUrl("abc123")
  * // → "https://stellar.expert/explorer/testnet/tx/abc123"
+ * getStellarExpertTxUrl("abc123", "public")
+ * // → "https://stellar.expert/explorer/public/tx/abc123"
  */
-export function getStellarExpertTxUrl(txHash: string): string {
-  const network = getStellarNetwork();
-  return `${STELLAR_EXPERT_BASE}/${network}/tx/${txHash}`;
+export function getStellarExpertTxUrl(txHash: string, network?: StellarNetwork): string {
+  const resolvedNetwork = network || getStellarNetwork();
+  return `${STELLAR_EXPERT_BASE}/${resolvedNetwork}/tx/${txHash}`;
 }

--- a/fluxapay_frontend/src/lib/toastApiError.tsx
+++ b/fluxapay_frontend/src/lib/toastApiError.tsx
@@ -1,4 +1,5 @@
 import toast from "react-hot-toast";
+import * as Sentry from "@sentry/nextjs";
 import { ApiError } from "@/lib/api";
 
 /** User-friendly messages for known API error codes. */
@@ -62,6 +63,9 @@ export function toastApiError(error: unknown): void {
 
   try {
     toast.error(resolveMessage(error));
+    if (error instanceof ApiError && error.status >= 500) {
+      Sentry.captureException(error, { tags: { error_type: "api_error", status: error.status } });
+    }
   } catch {
     // never throw
   }
@@ -89,6 +93,9 @@ export function toastApiErrorWithRetry(
       ));
     } else {
       toast.error(message);
+    }
+    if (error instanceof ApiError && error.status >= 500) {
+      Sentry.captureException(error, { tags: { error_type: "api_error", status: error.status } });
     }
   } catch {
     // never throw


### PR DESCRIPTION
  ## Summary                                                                                                                                               
  Fixes TxHashLink explorer URLs for mainnet/testnet, corrects sidebar active states for nested routes, adds CSP and security headers to Next.js, and      
  integrates Sentry error tracking with source maps and merchant context.                                                                                  
                                                                                                                                                           
  ## Changes                                                                                                                                               
                                                            
  ### #607 — TxHashLink explorer URL based on network env                                                                                                  
  - `getStellarExpertTxUrl()` accepts optional `network` parameter to override `NEXT_PUBLIC_STELLAR_NETWORK`
  - TxHashLink component accepts optional `network` prop                                                                                                   
  - Adds unit tests verifying correct explorer URLs for both networks                                                                                      
                                                                                                                                                           
  ### #606 — Sidebar active state for nested routes                                                                                                        
  - Fixed route matching: `pathname === item.href || pathname.startsWith(item.href + "/")`
  - Correctly highlights parent nav for nested routes like `/dashboard/payments/[id]`                                                                      
  - Uses `aria-current="page"` for screen reader announcement
  - Adds comprehensive unit tests                                                                                                                          
                                                            
  ### #605 — Content Security Policy and security headers                                                                                                  
  - Configured CSP in next.config.ts:                       
    - `default-src 'self'`                                                                                                                                 
    - `script-src 'self' https://albedo.link` (Albedo wallet provider)
    - `frame-ancestors 'none'` on checkout routes                                                                                                          
    - `report-uri` support via env var                      
  - Fallback headers: X-Frame-Options: DENY, X-Content-Type-Options: nosniff, Referrer-Policy, Permissions-Policy                                          
                                                                                                                                                           
  ### #604 — Sentry error tracking                                                                                                                         
  - Added `@sentry/nextjs@^8.14.0` to dependencies                                                                                                         
  - Configured in next.config.ts with DSN from env, webpack plugin for source maps                                                                         
  - GlobalErrorBoundary, error.tsx, toastApiError.tsx send errors to Sentry                                                                                
  - Merchant context utility (no PII)                                                                                                                      
  - sentry.client.config.ts and sentry.server.config.ts for SDK initialization                                                                             
                                                                                                                                                           
  Closes #607, Closes #606, Closes #605, Closes #604    