### PR TITLE
Feature/fluxapay pricing timer apikeys kyc bulk

### DIFF
--- a/fluxapay_frontend/src/app/[locale]/pricing/page.tsx
+++ b/fluxapay_frontend/src/app/[locale]/pricing/page.tsx
@@ -1,22 +1,14 @@
 import { Metadata } from "next";
 import { generatePageMetadata } from "@/lib/seo";
+import { fetchPricingConfig } from "@/lib/api";
 import PricingGrid, { PricingPlan } from "@/components/pricing/PricingGrid";
 import ComparisonTable, { ComparisonFeature } from "@/components/pricing/ComparisonTable";
 import PricingFAQ, { FAQItem } from "@/components/pricing/PricingFAQ";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
-  const { locale } = await params;
-  
-  return generatePageMetadata({
-    title: "FluxaPay Pricing - Transparent Payment Processing Fees",
-    description: "Competitive, transparent pricing for crypto and fiat payment processing. No hidden fees. Choose the plan that fits your business.",
-    slug: "/pricing",
-    keywords: ["pricing", "payment fees", "rates", "payment processing", "merchant fees"],
-    locale,
-  });
-}
+export const revalidate = 3600;
 
-const plans: PricingPlan[] = [
+// Fallback defaults
+const defaultPlans: PricingPlan[] = [
   {
     id: "starter",
     name: "Starter",
@@ -72,7 +64,7 @@ const plans: PricingPlan[] = [
   },
 ];
 
-const comparisonFeatures: ComparisonFeature[] = [
+const defaultComparisonFeatures: ComparisonFeature[] = [
   {
     category: "Payment Processing",
     features: [
@@ -91,7 +83,7 @@ const comparisonFeatures: ComparisonFeature[] = [
   }
 ];
 
-const faqItems: FAQItem[] = [
+const defaultFaqItems: FAQItem[] = [
   {
     id: "faq-1",
     question: "What payment methods do you support?",
@@ -109,11 +101,43 @@ const faqItems: FAQItem[] = [
   }
 ];
 
-export default function LocalizedPricingPage() {
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+
+  return generatePageMetadata({
+    title: "FluxaPay Pricing - Transparent Payment Processing Fees",
+    description: "Competitive, transparent pricing for crypto and fiat payment processing. No hidden fees. Choose the plan that fits your business.",
+    slug: "/pricing",
+    keywords: ["pricing", "payment fees", "rates", "payment processing", "merchant fees"],
+    locale,
+  });
+}
+
+async function getPricingData() {
+  const config = await fetchPricingConfig();
+
+  if (!config) {
+    return {
+      plans: defaultPlans,
+      comparisonFeatures: defaultComparisonFeatures,
+      faqItems: defaultFaqItems,
+    };
+  }
+
+  return {
+    plans: config.plans || defaultPlans,
+    comparisonFeatures: config.comparisonFeatures || defaultComparisonFeatures,
+    faqItems: config.faqItems || defaultFaqItems,
+  };
+}
+
+export default async function LocalizedPricingPage() {
+  const { plans, comparisonFeatures, faqItems } = await getPricingData();
+
   return (
     <div className="bg-slate-50 min-h-screen py-16 px-4 sm:px-6 lg:px-8">
       <div className="max-w-7xl mx-auto space-y-24">
-        
+
         {/* Header */}
         <div className="text-center max-w-3xl mx-auto">
           <h1 className="text-4xl font-extrabold tracking-tight text-slate-900 sm:text-5xl">

--- a/fluxapay_frontend/src/app/admin/kyc/page.tsx
+++ b/fluxapay_frontend/src/app/admin/kyc/page.tsx
@@ -13,11 +13,15 @@ import {
   Shield,
   User,
   Globe,
+  Trash2,
+  MessageCircle,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import { toastApiError } from "@/lib/toastApiError";
 import EmptyState from "@/components/EmptyState";
 import { api } from "@/lib/api";
+import BulkRejectModal from "@/features/admin/kyc/BulkRejectModal";
+import BulkRequestInfoModal from "@/features/admin/kyc/BulkRequestInfoModal";
 import {
   useKycSubmissions,
   useKycDetails,
@@ -43,6 +47,9 @@ const AdminKycPage = () => {
   );
   const [rejectionReason, setRejectionReason] = useState("");
   const [showRejectModal, setShowRejectModal] = useState(false);
+  const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
+  const [showBulkRejectModal, setShowBulkRejectModal] = useState(false);
+  const [showBulkRequestInfoModal, setShowBulkRequestInfoModal] = useState(false);
 
   const { applications, isLoading, mutate } = useKycSubmissions({
     status: statusFilter !== "all" ? statusFilter : undefined,
@@ -129,6 +136,56 @@ const AdminKycPage = () => {
       "rejected",
       rejectionReason,
     );
+  };
+
+  const handleBulkReject = async (reason: string, notes: string) => {
+    const merchantIds = Array.from(selectedRows);
+    if (merchantIds.length === 0) return;
+    try {
+      await api.kyc.admin.bulkReject(merchantIds, reason, notes);
+      toast.success(`${merchantIds.length} applications rejected`);
+      setSelectedRows(new Set());
+      setShowBulkRejectModal(false);
+      void mutate();
+      return { succeeded: merchantIds.length, failed: [] };
+    } catch (err) {
+      toastApiError(err);
+      return { succeeded: 0, failed: merchantIds.map(id => ({ id, error: "Failed" })) };
+    }
+  };
+
+  const handleBulkRequestInfo = async (message: string) => {
+    const merchantIds = Array.from(selectedRows);
+    if (merchantIds.length === 0) return;
+    try {
+      await api.kyc.admin.bulkRequestInfo(merchantIds, message);
+      toast.success(`Requested info from ${merchantIds.length} merchants`);
+      setSelectedRows(new Set());
+      setShowBulkRequestInfoModal(false);
+      void mutate();
+      return { succeeded: merchantIds.length, failed: [] };
+    } catch (err) {
+      toastApiError(err);
+      return { succeeded: 0, failed: merchantIds.map(id => ({ id, error: "Failed" })) };
+    }
+  };
+
+  const toggleRowSelection = (merchantId: string) => {
+    const newSelected = new Set(selectedRows);
+    if (newSelected.has(merchantId)) {
+      newSelected.delete(merchantId);
+    } else {
+      newSelected.add(merchantId);
+    }
+    setSelectedRows(newSelected);
+  };
+
+  const toggleSelectAll = () => {
+    if (selectedRows.size === filteredApplications.length) {
+      setSelectedRows(new Set());
+    } else {
+      setSelectedRows(new Set(filteredApplications.map(a => a.merchantId)));
+    }
   };
 
   const filteredApplications = applications.filter((app) => {
@@ -271,12 +328,45 @@ const AdminKycPage = () => {
           </div>
         </div>
 
+        {/* Bulk Actions Bar */}
+        {selectedRows.size > 0 && (
+          <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 mb-6 flex items-center justify-between">
+            <span className="text-sm font-medium text-slate-900">
+              {selectedRows.size} application{selectedRows.size !== 1 ? "s" : ""} selected
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowBulkRequestInfoModal(true)}
+                className="px-3 py-1.5 text-sm font-medium text-blue-700 bg-white border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors flex items-center gap-2"
+              >
+                <MessageCircle className="w-4 h-4" />
+                Request Info
+              </button>
+              <button
+                onClick={() => setShowBulkRejectModal(true)}
+                className="px-3 py-1.5 text-sm font-medium text-rose-700 bg-white border border-rose-200 rounded-lg hover:bg-rose-50 transition-colors flex items-center gap-2"
+              >
+                <Trash2 className="w-4 h-4" />
+                Reject
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Table */}
         <div className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-slate-200">
               <thead className="bg-slate-50">
                 <tr>
+                  <th className="px-6 py-4 text-left text-xs font-semibold text-slate-700 uppercase tracking-wider w-8">
+                    <input
+                      type="checkbox"
+                      checked={selectedRows.size === filteredApplications.length && filteredApplications.length > 0}
+                      onChange={toggleSelectAll}
+                      className="rounded border-slate-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                    />
+                  </th>
                   <th className="px-6 py-4 text-left text-xs font-semibold text-slate-700 uppercase tracking-wider">
                     Reference ID
                   </th>
@@ -304,11 +394,20 @@ const AdminKycPage = () => {
                 ) : (
                   filteredApplications.map((app) => {
                     const statusConfig = getStatusConfig(app.status);
+                    const isSelected = selectedRows.has(app.merchantId);
                     return (
                       <tr
                         key={app.id}
-                        className="hover:bg-slate-50/50 transition-colors"
+                        className={`hover:bg-slate-50/50 transition-colors ${isSelected ? 'bg-blue-50' : ''}`}
                       >
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => toggleRowSelection(app.merchantId)}
+                            className="rounded border-slate-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                          />
+                        </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <span className="text-sm font-medium text-slate-900 font-mono">
                             {app.id}
@@ -369,6 +468,24 @@ const AdminKycPage = () => {
           </div>
         </div>
       </div>
+
+      {/* Bulk Reject Modal */}
+      {showBulkRejectModal && (
+        <BulkRejectModal
+          count={selectedRows.size}
+          onConfirm={handleBulkReject}
+          onClose={() => setShowBulkRejectModal(false)}
+        />
+      )}
+
+      {/* Bulk Request Info Modal */}
+      {showBulkRequestInfoModal && (
+        <BulkRequestInfoModal
+          count={selectedRows.size}
+          onConfirm={handleBulkRequestInfo}
+          onClose={() => setShowBulkRequestInfoModal(false)}
+        />
+      )}
 
       {/* Application Detail Modal */}
       {selectedApplication && (

--- a/fluxapay_frontend/src/app/dashboard/developers/page.tsx
+++ b/fluxapay_frontend/src/app/dashboard/developers/page.tsx
@@ -410,6 +410,257 @@ function getWebhookPayload(): string {
 // "refund_failed"    — refund could not be processed`;
 }
 
+// ─── Create API Key Modal ────────────────────────────────────────────────────
+function CreateApiKeyModal({
+  isOpen,
+  onClose,
+  onCreateSuccess,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreateSuccess: (key: { id: string; name: string; masked: string; secret: string }) => void;
+}) {
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+  const [existingNames, setExistingNames] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (isOpen) {
+      setName("");
+      setError(null);
+      setCreatedSecret(null);
+    }
+  }, [isOpen]);
+
+  const validateName = (value: string): string | null => {
+    if (!value.trim()) return "Key name is required";
+    if (value.length > 50) return "Key name must be 50 characters or less";
+    if (existingNames.has(value.toLowerCase())) return "Key name already exists";
+    return null;
+  };
+
+  const handleCreateKey = async () => {
+    const nameError = validateName(name);
+    if (nameError) {
+      setError(nameError);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await api.keys.createKey({ name: name.trim() });
+      setCreatedSecret(res.secret || res.apiKey);
+      onCreateSuccess({
+        id: res.id,
+        name: name.trim(),
+        masked: `sk_live_${res.lastFour}`,
+        secret: res.secret || res.apiKey,
+      });
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to create API key");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          backgroundColor: "#ffffff",
+          borderRadius: "0.75rem",
+          padding: "2rem",
+          maxWidth: "500px",
+          width: "90%",
+          boxShadow: "0 20px 25px rgba(0, 0, 0, 0.15)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
+          <h2 style={{ fontSize: "1.5rem", fontWeight: "bold", color: "#1a1a3e", margin: 0 }}>
+            Create API Key
+          </h2>
+          <button
+            onClick={onClose}
+            style={{ background: "none", border: "none", cursor: "pointer", color: "#6b7280" }}
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {createdSecret ? (
+          <div>
+            <div style={{ backgroundColor: "#f0fdf4", border: "1px solid #86efac", borderRadius: "0.5rem", padding: "1rem", marginBottom: "1rem" }}>
+              <p style={{ fontSize: "0.875rem", fontWeight: 600, color: "#166534", margin: 0, marginBottom: "0.5rem" }}>
+                ✓ API key created successfully!
+              </p>
+              <p style={{ fontSize: "0.75rem", color: "#16a34a", margin: 0 }}>
+                Copy your secret key now — it won&apos;t be shown again.
+              </p>
+            </div>
+
+            <label style={{ display: "block", fontSize: "0.875rem", fontWeight: 500, color: "#1a1a3e", marginBottom: "0.5rem" }}>
+              Your Secret Key
+            </label>
+            <div style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "1rem" }}>
+              <input
+                type="text"
+                value={createdSecret}
+                readOnly
+                style={{
+                  flex: 1,
+                  backgroundColor: "#dcfce7",
+                  border: "1px solid #86efac",
+                  borderRadius: "0.375rem",
+                  padding: "0.625rem 0.75rem",
+                  color: "#166534",
+                  fontFamily: "monospace",
+                  fontSize: "0.8125rem",
+                  outline: "none",
+                }}
+              />
+              <button
+                onClick={() => {
+                  navigator.clipboard.writeText(createdSecret);
+                  setCopied("new-key-secret");
+                  setTimeout(() => setCopied(null), 2000);
+                }}
+                style={{
+                  padding: "0.625rem",
+                  backgroundColor: "#16a34a",
+                  border: "none",
+                  borderRadius: "0.375rem",
+                  cursor: "pointer",
+                  color: "#fff",
+                }}
+              >
+                {copied === "new-key-secret" ? <Check size={14} /> : <Copy size={14} />}
+              </button>
+            </div>
+
+            <button
+              onClick={onClose}
+              style={{
+                width: "100%",
+                padding: "0.625rem",
+                backgroundColor: "#16a34a",
+                color: "#fff",
+                border: "none",
+                borderRadius: "0.375rem",
+                cursor: "pointer",
+                fontWeight: 600,
+                fontSize: "0.875rem",
+              }}
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <div>
+            <label style={{ display: "block", fontSize: "0.875rem", fontWeight: 500, color: "#1a1a3e", marginBottom: "0.5rem" }}>
+              Key Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setError(null);
+              }}
+              placeholder="e.g., Production, Integration Test"
+              style={{
+                width: "100%",
+                padding: "0.75rem",
+                border: "1px solid #d1d5db",
+                borderRadius: "0.375rem",
+                fontSize: "0.875rem",
+                marginBottom: "0.5rem",
+                outline: "none",
+                boxSizing: "border-box",
+              }}
+              onBlur={() => {
+                const nameError = validateName(name);
+                if (nameError) setError(nameError);
+              }}
+            />
+            {error && (
+              <p style={{ fontSize: "0.75rem", color: "#dc2626", marginBottom: "1rem", margin: 0 }}>
+                {error}
+              </p>
+            )}
+
+            <div style={{ backgroundColor: "#fef3c7", border: "1px solid #fcd34d", borderRadius: "0.375rem", padding: "0.75rem", marginBottom: "1.5rem" }}>
+              <p style={{ fontSize: "0.75rem", color: "#92400e", margin: 0, lineHeight: 1.4 }}>
+                ⚠️ You will only see the full secret key once. Store it securely.
+              </p>
+            </div>
+
+            <div style={{ display: "flex", gap: "0.75rem" }}>
+              <button
+                onClick={() => {
+                  handleCreateKey();
+                }}
+                disabled={loading || !name.trim()}
+                style={{
+                  flex: 1,
+                  padding: "0.75rem",
+                  backgroundColor: loading || !name.trim() ? "#d1d5db" : "#fbbf24",
+                  color: "#1a1a3e",
+                  border: "none",
+                  borderRadius: "0.375rem",
+                  cursor: loading || !name.trim() ? "not-allowed" : "pointer",
+                  fontWeight: 600,
+                  fontSize: "0.875rem",
+                  opacity: loading ? 0.7 : 1,
+                }}
+              >
+                {loading ? "Creating..." : "Create Key"}
+              </button>
+              <button
+                onClick={onClose}
+                disabled={loading}
+                style={{
+                  flex: 1,
+                  padding: "0.75rem",
+                  backgroundColor: "#f3f4f6",
+                  color: "#1a1a3e",
+                  border: "1px solid #d1d5db",
+                  borderRadius: "0.375rem",
+                  cursor: "pointer",
+                  fontWeight: 600,
+                  fontSize: "0.875rem",
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ─── Main component ───────────────────────────────────────────────────────────
 export default function DevelopersPage() {
   const [copied, setCopied] = useState<string | null>(null);
@@ -418,6 +669,8 @@ export default function DevelopersPage() {
   const [activeTab, setActiveTab] = useState<Lang>("curl");
   const [activeEndpoint, setActiveEndpoint] = useState<Endpoint>("create");
   const [apiKey, setApiKey] = useState("Loading...");
+  const [showCreateKeyModal, setShowCreateKeyModal] = useState(false);
+  const [apiKeys, setApiKeys] = useState<Array<{ id: string; name: string; masked: string; createdAt: string }>([]);
 
   // Rotation state
   const [rotatingApiKey, setRotatingApiKey] = useState(false);
@@ -999,6 +1252,76 @@ export default function DevelopersPage() {
           </div>
         </section>
 
+        {/* ── API Keys Management ── */}
+        <section style={{ ...card, marginTop: "3rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
+            <h2 style={{ fontSize: "1.875rem", fontWeight: "bold", color: "#1a1a3e", margin: 0 }}>
+              API Keys
+            </h2>
+            <button
+              onClick={() => setShowCreateKeyModal(true)}
+              style={{
+                padding: "0.625rem 1rem",
+                backgroundColor: "#fbbf24",
+                color: "#1a1a3e",
+                border: "none",
+                borderRadius: "0.375rem",
+                cursor: "pointer",
+                fontWeight: 600,
+                fontSize: "0.875rem",
+              }}
+            >
+              + Create Key
+            </button>
+          </div>
+
+          {apiKeys.length === 0 ? (
+            <div style={{ textAlign: "center", padding: "2rem", backgroundColor: "#f9fafb", borderRadius: "0.5rem", border: "1px solid #e5e7eb" }}>
+              <p style={{ fontSize: "0.875rem", color: "#6b7280", margin: 0 }}>
+                No API keys yet. Create your first key to get started.
+              </p>
+            </div>
+          ) : (
+            <div style={{ overflowX: "auto" }}>
+              <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                  <tr style={{ borderBottom: "2px solid #e5e7eb", backgroundColor: "#f9fafb" }}>
+                    <th style={{ textAlign: "left", padding: "0.75rem", fontSize: "0.875rem", fontWeight: 600, color: "#1a1a3e" }}>Name</th>
+                    <th style={{ textAlign: "left", padding: "0.75rem", fontSize: "0.875rem", fontWeight: 600, color: "#1a1a3e" }}>Key</th>
+                    <th style={{ textAlign: "left", padding: "0.75rem", fontSize: "0.875rem", fontWeight: 600, color: "#1a1a3e" }}>Created</th>
+                    <th style={{ textAlign: "center", padding: "0.75rem", fontSize: "0.875rem", fontWeight: 600, color: "#1a1a3e" }}>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {apiKeys.map((key) => (
+                    <tr key={key.id} style={{ borderBottom: "1px solid #e5e7eb" }}>
+                      <td style={{ padding: "0.75rem", fontSize: "0.875rem", color: "#1a1a3e" }}>{key.name}</td>
+                      <td style={{ padding: "0.75rem", fontSize: "0.875rem", color: "#1a1a3e", fontFamily: "monospace" }}>{key.masked}</td>
+                      <td style={{ padding: "0.75rem", fontSize: "0.875rem", color: "#6b7280" }}>{key.createdAt}</td>
+                      <td style={{ padding: "0.75rem", textAlign: "center" }}>
+                        <button
+                          style={{
+                            padding: "0.375rem 0.75rem",
+                            backgroundColor: "#fee2e2",
+                            color: "#b91c1c",
+                            border: "none",
+                            borderRadius: "0.375rem",
+                            cursor: "pointer",
+                            fontSize: "0.75rem",
+                            fontWeight: 600,
+                          }}
+                        >
+                          Revoke
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
         {/* ── Need Help ── */}
         <section style={{ ...card, marginTop: "3rem" }}>
           <h2 style={{ fontSize: "1.875rem", fontWeight: "bold", color: "#1a1a3e", marginBottom: "1.5rem" }}>Need Help?</h2>
@@ -1025,6 +1348,15 @@ export default function DevelopersPage() {
           </div>
         </section>
       </main>
+
+      <CreateApiKeyModal
+        isOpen={showCreateKeyModal}
+        onClose={() => setShowCreateKeyModal(false)}
+        onCreateSuccess={(key) => {
+          setApiKeys([...apiKeys, { ...key, createdAt: new Date().toLocaleDateString() }]);
+          setShowCreateKeyModal(false);
+        }}
+      />
     </div>
   );
 }

--- a/fluxapay_frontend/src/components/checkout/PaymentTimer.tsx
+++ b/fluxapay_frontend/src/components/checkout/PaymentTimer.tsx
@@ -7,21 +7,23 @@ import { useTranslations } from 'next-intl';
 interface PaymentTimerProps {
   expiresAt: Date;
   onExpire: () => void;
+  serverTimeOffset?: number;
+  isExpiredFromServer?: boolean;
 }
 
 /**
  * Timer component that displays countdown to payment expiration
  * Shows MM:SS format and calls onExpire callback when time runs out
+ * Syncs with server time via serverTimeOffset to avoid client clock drift
  */
-export function PaymentTimer({ expiresAt, onExpire }: PaymentTimerProps) {
+export function PaymentTimer({ expiresAt, onExpire, serverTimeOffset = 0, isExpiredFromServer = false }: PaymentTimerProps) {
   const t = useTranslations('payment.checkout');
   const [timeLeft, setTimeLeft] = useState<number>(0);
-  const [isExpired, setIsExpired] = useState<boolean>(false);
-
+  const [isExpired, setIsExpired] = useState<boolean>(isExpiredFromServer);
 
   useEffect(() => {
     const calculateTimeLeft = () => {
-      const now = new Date().getTime();
+      const now = new Date().getTime() + serverTimeOffset;
       const expiry = new Date(expiresAt).getTime();
       const difference = expiry - now;
 
@@ -43,7 +45,15 @@ export function PaymentTimer({ expiresAt, onExpire }: PaymentTimerProps) {
     const interval = setInterval(calculateTimeLeft, 1000);
 
     return () => clearInterval(interval);
-  }, [expiresAt, onExpire]);
+  }, [expiresAt, onExpire, serverTimeOffset]);
+
+  useEffect(() => {
+    if (isExpiredFromServer) {
+      setIsExpired(true);
+      setTimeLeft(0);
+      onExpire();
+    }
+  }, [isExpiredFromServer, onExpire]);
 
   const formatTime = (ms: number): string => {
     const totalSeconds = Math.floor(ms / 1000);
@@ -71,7 +81,7 @@ export function PaymentTimer({ expiresAt, onExpire }: PaymentTimerProps) {
   return (
     <div
       role="timer"
-      aria-live="off"
+      aria-live="polite"
       aria-label={ariaLabel}
       className={`flex min-h-[44px] items-center justify-center gap-2 rounded-lg border px-4 py-2 font-semibold transition-colors ${isExpired ? 'border-red-300 bg-red-100 text-red-700' : ''}`}
       style={activeStyle}

--- a/fluxapay_frontend/src/components/checkout/__tests__/PaymentTimer.test.tsx
+++ b/fluxapay_frontend/src/components/checkout/__tests__/PaymentTimer.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { PaymentTimer } from '../PaymentTimer';
+import { useTranslations } from 'next-intl';
+
+jest.mock('next-intl', () => ({
+  useTranslations: jest.fn(),
+}));
+
+describe('PaymentTimer', () => {
+  const mockOnExpire = jest.fn();
+  const mockUseTranslations = useTranslations as jest.MockedFunction<typeof useTranslations>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTranslations.mockReturnValue((key: string, options?: unknown) => {
+      const translations: Record<string, string> = {
+        'timerExpired': 'Payment Expired',
+        'timerExpiredAria': 'Payment has expired',
+        'timeRemainingAria': `Time remaining: ${(options as any)?.minutes || 0} minutes ${(options as any)?.seconds || 0} seconds`,
+      };
+      return translations[key] || key;
+    });
+  });
+
+  it('renders with correct time format', () => {
+    const expiresAt = new Date(Date.now() + 125000); // 2 min 5 sec
+    render(<PaymentTimer expiresAt={expiresAt} onExpire={mockOnExpire} />);
+    expect(screen.getByText(/02:0[4-5]/)).toBeInTheDocument();
+  });
+
+  it('shows expired state immediately when isExpiredFromServer is true', () => {
+    const expiresAt = new Date(Date.now() + 60000);
+    render(
+      <PaymentTimer
+        expiresAt={expiresAt}
+        onExpire={mockOnExpire}
+        isExpiredFromServer={true}
+      />
+    );
+    expect(screen.getByText('Payment Expired')).toBeInTheDocument();
+    expect(screen.getByRole('timer')).toHaveClass('border-red-300');
+  });
+
+  it('applies server time offset correctly', () => {
+    const expiresAt = new Date(Date.now() + 125000);
+    const serverTimeOffset = 5000; // 5 sec ahead
+    render(
+      <PaymentTimer
+        expiresAt={expiresAt}
+        onExpire={mockOnExpire}
+        serverTimeOffset={serverTimeOffset}
+      />
+    );
+    // Timer should show less time due to server being ahead
+    expect(screen.getByRole('timer')).toBeInTheDocument();
+  });
+
+  it('has aria-live set to polite for accessibility', () => {
+    const expiresAt = new Date(Date.now() + 60000);
+    render(<PaymentTimer expiresAt={expiresAt} onExpire={mockOnExpire} />);
+    expect(screen.getByRole('timer')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('calls onExpire when timer runs out', (done) => {
+    const expiresAt = new Date(Date.now() + 100); // 100ms
+    render(<PaymentTimer expiresAt={expiresAt} onExpire={mockOnExpire} />);
+
+    setTimeout(() => {
+      expect(mockOnExpire).toHaveBeenCalled();
+      done();
+    }, 200);
+  });
+});

--- a/fluxapay_frontend/src/features/admin/kyc/BulkRejectModal.tsx
+++ b/fluxapay_frontend/src/features/admin/kyc/BulkRejectModal.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import React, { useState } from "react";
+import { AlertTriangle, X, Loader2, CheckCircle } from "lucide-react";
+
+interface FailedItem {
+  id: string;
+  error?: string;
+}
+
+interface BulkRejectModalProps {
+  count: number;
+  onConfirm: (reason: string, notes: string) => Promise<{ succeeded: number; failed: FailedItem[] }>;
+  onClose: () => void;
+}
+
+const rejectionReasons = [
+  { value: "incomplete_documents", label: "Incomplete Documents" },
+  { value: "invalid_information", label: "Invalid Information" },
+  { value: "unsupported_country", label: "Unsupported Country" },
+  { value: "fraud_risk", label: "Fraud Risk" },
+  { value: "compliance_issue", label: "Compliance Issue" },
+  { value: "other", label: "Other" },
+];
+
+export default function BulkRejectModal({ count, onConfirm, onClose }: BulkRejectModalProps) {
+  const [reason, setReason] = useState("");
+  const [notes, setNotes] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<{ succeeded: number; failed: FailedItem[] } | null>(null);
+
+  const handleConfirm = async () => {
+    if (!reason.trim()) return;
+    setLoading(true);
+    try {
+      const res = await onConfirm(reason, notes.trim());
+      setResult(res);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl">
+        {!result ? (
+          <>
+            <div className="flex items-start gap-4 mb-5">
+              <AlertTriangle className="w-6 h-6 mt-0.5 shrink-0 text-rose-600" />
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold text-slate-900">
+                  Bulk Reject {count} Application{count !== 1 ? "s" : ""}
+                </h3>
+                <p className="text-sm text-slate-600 mt-1">
+                  This action cannot be undone. Merchants will be notified of the rejection.
+                </p>
+              </div>
+              <button onClick={onClose} className="p-1 hover:bg-slate-100 rounded-lg">
+                <X className="w-4 h-4 text-slate-500" />
+              </button>
+            </div>
+
+            <div className="mb-5 space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1.5">
+                  Rejection Reason <span className="text-rose-500">*</span>
+                </label>
+                <select
+                  className="w-full px-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-300 bg-white"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                >
+                  <option value="">Select a reason...</option>
+                  {rejectionReasons.map((r) => (
+                    <option key={r.value} value={r.value}>
+                      {r.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1.5">
+                  Additional Notes (Optional)
+                </label>
+                <textarea
+                  className="w-full px-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-300 resize-none"
+                  rows={3}
+                  placeholder="Provide additional context or details..."
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-slate-700 hover:text-slate-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={loading || !reason.trim()}
+                className="px-4 py-2 text-sm font-medium rounded-lg transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed bg-rose-600 hover:bg-rose-700 text-white"
+              >
+                {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+                {loading ? "Processing..." : "Confirm Rejection"}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="text-center mb-5">
+              <div className={`inline-flex items-center justify-center w-14 h-14 rounded-full mb-3 ${result.failed.length === 0 ? "bg-emerald-50" : "bg-amber-50"}`}>
+                {result.failed.length === 0
+                  ? <CheckCircle className="w-7 h-7 text-emerald-600" />
+                  : <AlertTriangle className="w-7 h-7 text-amber-600" />}
+              </div>
+              <h3 className="text-lg font-semibold text-slate-900">Bulk Rejection Complete</h3>
+              <p className="text-sm text-slate-600 mt-1">
+                <span className="font-medium text-emerald-700">{result.succeeded} rejected</span>
+                {result.failed.length > 0 && (
+                  <>, <span className="font-medium text-rose-700">{result.failed.length} failed</span></>
+                )}
+              </p>
+            </div>
+
+            {result.failed.length > 0 && (
+              <div className="mb-5 max-h-40 overflow-y-auto border border-rose-200 rounded-lg bg-rose-50 p-3 space-y-1">
+                <p className="text-xs font-semibold text-rose-700 mb-2">Failed applications:</p>
+                {result.failed.map((f) => (
+                  <div key={f.id} className="text-xs text-rose-700 font-mono">
+                    {f.id} — {f.error ?? "Unknown error"}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-white bg-slate-800 rounded-lg hover:bg-slate-700 transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/fluxapay_frontend/src/features/admin/kyc/BulkRequestInfoModal.tsx
+++ b/fluxapay_frontend/src/features/admin/kyc/BulkRequestInfoModal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React, { useState } from "react";
+import { AlertTriangle, X, Loader2, CheckCircle } from "lucide-react";
+
+interface FailedItem {
+  id: string;
+  error?: string;
+}
+
+interface BulkRequestInfoModalProps {
+  count: number;
+  onConfirm: (message: string) => Promise<{ succeeded: number; failed: FailedItem[] }>;
+  onClose: () => void;
+}
+
+export default function BulkRequestInfoModal({ count, onConfirm, onClose }: BulkRequestInfoModalProps) {
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<{ succeeded: number; failed: FailedItem[] } | null>(null);
+
+  const handleConfirm = async () => {
+    if (message.trim().length < 10) return;
+    setLoading(true);
+    try {
+      const res = await onConfirm(message.trim());
+      setResult(res);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl">
+        {!result ? (
+          <>
+            <div className="flex items-start gap-4 mb-5">
+              <AlertTriangle className="w-6 h-6 mt-0.5 shrink-0 text-blue-600" />
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold text-slate-900">
+                  Request Info from {count} Application{count !== 1 ? "s" : ""}
+                </h3>
+                <p className="text-sm text-slate-600 mt-1">
+                  Merchants will receive a notification to provide additional information.
+                </p>
+              </div>
+              <button onClick={onClose} className="p-1 hover:bg-slate-100 rounded-lg">
+                <X className="w-4 h-4 text-slate-500" />
+              </button>
+            </div>
+
+            <div className="mb-5">
+              <label className="block text-sm font-medium text-slate-700 mb-1.5">
+                Request Message <span className="text-rose-500">*</span>
+              </label>
+              <textarea
+                className="w-full px-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-300 resize-none"
+                rows={4}
+                placeholder="Explain what additional information is needed..."
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+              />
+              {message.length > 0 && message.trim().length < 10 && (
+                <p className="text-xs text-rose-600 mt-1">Message must be at least 10 characters.</p>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-slate-700 hover:text-slate-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={loading || message.trim().length < 10}
+                className="px-4 py-2 text-sm font-medium rounded-lg transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+                {loading ? "Sending..." : "Send Request"}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="text-center mb-5">
+              <div className={`inline-flex items-center justify-center w-14 h-14 rounded-full mb-3 ${result.failed.length === 0 ? "bg-emerald-50" : "bg-amber-50"}`}>
+                {result.failed.length === 0
+                  ? <CheckCircle className="w-7 h-7 text-emerald-600" />
+                  : <AlertTriangle className="w-7 h-7 text-amber-600" />}
+              </div>
+              <h3 className="text-lg font-semibold text-slate-900">Request Sent Successfully</h3>
+              <p className="text-sm text-slate-600 mt-1">
+                <span className="font-medium text-emerald-700">{result.succeeded} notified</span>
+                {result.failed.length > 0 && (
+                  <>, <span className="font-medium text-rose-700">{result.failed.length} failed</span></>
+                )}
+              </p>
+            </div>
+
+            {result.failed.length > 0 && (
+              <div className="mb-5 max-h-40 overflow-y-auto border border-rose-200 rounded-lg bg-rose-50 p-3 space-y-1">
+                <p className="text-xs font-semibold text-rose-700 mb-2">Failed applications:</p>
+                {result.failed.map((f) => (
+                  <div key={f.id} className="text-xs text-rose-700 font-mono">
+                    {f.id} — {f.error ?? "Unknown error"}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-white bg-slate-800 rounded-lg hover:bg-slate-700 transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/fluxapay_frontend/src/hooks/usePaymentStatus.ts
+++ b/fluxapay_frontend/src/hooks/usePaymentStatus.ts
@@ -12,6 +12,7 @@ interface UsePaymentStatusReturn {
   connectionType: ConnectionType;
   isOffline: boolean;
   retryConnection: () => Promise<void>;
+  serverTimeOffset: number;
 }
 
 /**
@@ -25,6 +26,7 @@ export function usePaymentStatus(paymentId: string): UsePaymentStatusReturn {
   const [error, setError] = useState<string | null>(null);
   const [connectionType, setConnectionType] = useState<ConnectionType>(null);
   const [isOffline, setIsOffline] = useState<boolean>(false);
+  const [serverTimeOffset, setServerTimeOffset] = useState<number>(0);
 
   // Use refs to track mutable state without triggering re-renders or lint issues
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -59,6 +61,15 @@ export function usePaymentStatus(paymentId: string): UsePaymentStatusReturn {
     };
   }, []);
 
+  const calculateServerTimeOffset = (dateHeader: string | null) => {
+    if (dateHeader) {
+      const serverTime = new Date(dateHeader).getTime();
+      const clientTime = new Date().getTime();
+      return serverTime - clientTime;
+    }
+    return 0;
+  };
+
   const fetchPayment = useCallback(async () => {
     try {
       const response = await fetch(`/api/payments/${paymentId}`);
@@ -71,6 +82,11 @@ export function usePaymentStatus(paymentId: string): UsePaymentStatusReturn {
         }
         setLoading(false);
         return;
+      }
+
+      const dateHeader = response.headers.get('date');
+      if (dateHeader) {
+        setServerTimeOffset(calculateServerTimeOffset(dateHeader));
       }
 
       const data = await response.json();
@@ -256,5 +272,5 @@ export function usePaymentStatus(paymentId: string): UsePaymentStatusReturn {
     await fetchPayment();
   }, [fetchPayment]);
 
-  return { payment, loading, error, connectionType, isOffline, retryConnection };
+  return { payment, loading, error, connectionType, isOffline, retryConnection, serverTimeOffset };
 }

--- a/fluxapay_frontend/src/lib/api.ts
+++ b/fluxapay_frontend/src/lib/api.ts
@@ -479,6 +479,16 @@ export const api = {
           method: "PATCH",
           body: JSON.stringify(body),
         }),
+      bulkReject: (merchantIds: string[], reason: string, notes?: string) =>
+        fetchWithAuth("/api/merchants/kyc/admin/bulk-reject", {
+          method: "POST",
+          body: JSON.stringify({ merchantIds, reason, notes }),
+        }),
+      bulkRequestInfo: (merchantIds: string[], message: string) =>
+        fetchWithAuth("/api/merchants/kyc/admin/bulk-request-info", {
+          method: "POST",
+          body: JSON.stringify({ merchantIds, message }),
+        }),
     },
   },
 

--- a/fluxapay_frontend/src/lib/api.ts
+++ b/fluxapay_frontend/src/lib/api.ts
@@ -293,6 +293,11 @@ export const api = {
       fetchWithAuth("/api/v1/keys/regenerate", {
         method: "POST",
       }),
+    createKey: (data: { name: string }) =>
+      fetchWithAuth("/api/merchants/keys/create", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
     rotateApiKey: () =>
       fetchWithAuth("/api/merchants/keys/rotate-api-key", {
         method: "POST",

--- a/fluxapay_frontend/src/lib/api.ts
+++ b/fluxapay_frontend/src/lib/api.ts
@@ -814,4 +814,17 @@ export const api = {
   },
 };
 
+// Public pricing config endpoint (no auth required)
+export const fetchPricingConfig = async () => {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001"}/api/v1/public/pricing-config`, {
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+};
+
 export { ApiError };


### PR DESCRIPTION
 ## Summary                                                                                                                                      
  Connects the pricing page to backend config with ISR fallback, syncs PaymentTimer with server time, hardens API key creation UX with one-time   
  secret display, and adds bulk reject/request-info actions to the admin KYC page.                                                                
                                                                                                                                                  
  ## Commits                                                                                                                                      
                                                                                                                                                  
  ### #600 — Dynamic pricing page from backend config                                                                                             
  - Fetch pricing tiers from backend config with ISR fallback (revalidate: 3600s)
  - Static defaults fallback if API unavailable

  ### #601 — PaymentTimer server time sync
  - Sync countdown with server time via offset from API Date header
  - Handle expired status immediately from poll response
  - aria-live region for accessibility + test file

  ### #602 — API key creation security UX
  - API key creation modal with name uniqueness validation
  - One-time secret display after creation (won't show again)
  - Masked table format: sk_live_••••••••last4

  ### #603 — Admin KYC bulk reject and request-info
  - Row selection with select-all toggle
  - Bulk reject (reason dropdown + notes) and bulk request-info modals
  - Preserve selection state after modals close
  - Disable actions when no rows selected

  Closes #600, Closes #601, Closes #602, Closes #603