### PR TITLE
 [Frontend] Checkout page does not show merchant branding (logo, colours) fetched from backend

### DIFF
--- a/fluxapay_frontend/src/components/checkout/CheckoutBrandingShell.tsx
+++ b/fluxapay_frontend/src/components/checkout/CheckoutBrandingShell.tsx
@@ -32,7 +32,7 @@ function CheckoutBrandMark({
         {/* eslint-disable-next-line @next/next/no-img-element -- remote merchant URLs */}
         <img
           src={logoUrl}
-          alt=""
+          alt={merchantName ? `${merchantName} logo` : 'Merchant logo'}
           className="h-10 w-auto max-w-[200px] object-contain object-left"
           onError={() => setLogoFailed(true)}
           loading="eager"

--- a/fluxapay_frontend/src/components/checkout/__tests__/CheckoutBrandingShell.test.tsx
+++ b/fluxapay_frontend/src/components/checkout/__tests__/CheckoutBrandingShell.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CheckoutBrandingShell, DEFAULT_ACCENT } from '../CheckoutBrandingShell';
+
+describe('CheckoutBrandingShell', () => {
+  it('renders custom merchant logo, business name, and checkout accent CSS variable', () => {
+    const { container } = render(
+      <CheckoutBrandingShell
+        accentHex="#ff5500"
+        logoUrl="https://cdn.example.com/acme.png"
+        merchantName="Acme Store"
+        showBrandHeader
+      >
+        <button className="bg-[var(--checkout-accent)]">Pay now</button>
+      </CheckoutBrandingShell>
+    );
+
+    expect(screen.getByRole('img', { name: 'Acme Store logo' })).toHaveAttribute(
+      'src',
+      'https://cdn.example.com/acme.png'
+    );
+    expect(screen.getByText('Acme Store')).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveStyle({ '--checkout-accent': '#ff5500' });
+  });
+
+  it('falls back to FluxaPay default accent when merchant branding is absent', () => {
+    const { container } = render(
+      <CheckoutBrandingShell showBrandHeader>
+        <p>Checkout</p>
+      </CheckoutBrandingShell>
+    );
+
+    expect(container.firstElementChild).toHaveStyle({ '--checkout-accent': DEFAULT_ACCENT });
+    expect(screen.getByText('P')).toBeInTheDocument();
+  });
+});

--- a/fluxapay_frontend/src/hooks/usePaymentStatus.test.tsx
+++ b/fluxapay_frontend/src/hooks/usePaymentStatus.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePaymentResponse } from './usePaymentStatus';
+
+describe('normalizePaymentResponse', () => {
+  it('maps merchant_branding from charge API responses into checkout branding fields', () => {
+    const payment = normalizePaymentResponse({
+      id: 'ch_123',
+      amount: 25,
+      currency: 'USDC',
+      address: 'GABC',
+      expiresAt: '2026-06-27T12:00:00.000Z',
+      status: 'pending',
+      merchant_branding: {
+        logo_url: 'https://cdn.example.com/acme.png',
+        primary_color: 'ff5500',
+        business_name: 'Acme Store',
+      },
+    });
+
+    expect(payment.checkoutLogoUrl).toBe('https://cdn.example.com/acme.png');
+    expect(payment.checkoutAccentColor).toBe('#ff5500');
+    expect(payment.merchantName).toBe('Acme Store');
+    expect(payment.expiresAt).toEqual(new Date('2026-06-27T12:00:00.000Z'));
+  });
+
+  it('keeps legacy top-level checkout branding fields as fallbacks', () => {
+    const payment = normalizePaymentResponse({
+      id: 'pay_123',
+      amount: 10,
+      currency: 'USDC',
+      address: 'GDEF',
+      expiresAt: '2026-06-27T12:00:00.000Z',
+      status: 'pending',
+      merchantName: 'Legacy Store',
+      checkoutLogoUrl: 'https://cdn.example.com/legacy.png',
+      checkoutAccentColor: '#3366ff',
+    });
+
+    expect(payment.checkoutLogoUrl).toBe('https://cdn.example.com/legacy.png');
+    expect(payment.checkoutAccentColor).toBe('#3366ff');
+    expect(payment.merchantName).toBe('Legacy Store');
+  });
+});

--- a/fluxapay_frontend/src/hooks/usePaymentStatus.ts
+++ b/fluxapay_frontend/src/hooks/usePaymentStatus.ts
@@ -5,6 +5,74 @@ import { Payment } from '@/types/payment';
 
 type ConnectionType = 'sse' | 'polling' | null;
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeHexColor(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const color = value.trim();
+  if (/^#[0-9a-fA-F]{6}$/.test(color)) return color;
+  if (/^[0-9a-fA-F]{6}$/.test(color)) return `#${color}`;
+  return color;
+}
+
+export function normalizePaymentResponse(data: unknown): Payment {
+  const raw = asRecord(data);
+  const merchantBranding = asRecord(raw.merchant_branding ?? raw.merchantBranding);
+
+  return {
+    ...(raw as unknown as Payment),
+    expiresAt: new Date(raw.expiresAt as string),
+    merchantName: firstString(
+      raw.merchantName,
+      raw.merchant_name,
+      merchantBranding.businessName,
+      merchantBranding.business_name,
+      merchantBranding.merchantName,
+      merchantBranding.merchant_name
+    ),
+    checkoutLogoUrl: firstString(
+      raw.checkoutLogoUrl,
+      raw.checkout_logo_url,
+      merchantBranding.logoUrl,
+      merchantBranding.logo_url,
+      merchantBranding.checkoutLogoUrl,
+      merchantBranding.checkout_logo_url
+    ),
+    checkoutAccentColor: normalizeHexColor(firstString(
+      raw.checkoutAccentColor,
+      raw.checkout_accent_color,
+      merchantBranding.primaryColor,
+      merchantBranding.primary_color,
+      merchantBranding.brandColor,
+      merchantBranding.brand_color,
+      merchantBranding.accentColor,
+      merchantBranding.accent_color,
+      merchantBranding.checkoutAccentColor,
+      merchantBranding.checkout_accent_color
+    )),
+    paidAmount:
+      (raw.paidAmount as number | undefined) ??
+      (raw.paid_amount as number | undefined),
+    supportUrl:
+      (raw.supportUrl as string | undefined) ??
+      (raw.support_url as string | undefined),
+    transactionHash:
+      (raw.transactionHash as string | undefined) ??
+      (raw.transaction_hash as string | undefined),
+  };
+}
+
 interface UsePaymentStatusReturn {
   payment: Payment | null;
   loading: boolean;
@@ -90,26 +158,7 @@ export function usePaymentStatus(paymentId: string): UsePaymentStatusReturn {
       }
 
       const data = await response.json();
-      const raw = data as Record<string, unknown>;
-      const paymentData: Payment = {
-        ...(data as Payment),
-        expiresAt: new Date((data as { expiresAt?: string }).expiresAt as string),
-        checkoutLogoUrl:
-          (raw.checkoutLogoUrl as string | undefined) ??
-          (raw.checkout_logo_url as string | undefined),
-        checkoutAccentColor:
-          (raw.checkoutAccentColor as string | undefined) ??
-          (raw.checkout_accent_color as string | undefined),
-        paidAmount:
-          (raw.paidAmount as number | undefined) ??
-          (raw.paid_amount as number | undefined),
-        supportUrl:
-          (raw.supportUrl as string | undefined) ??
-          (raw.support_url as string | undefined),
-        transactionHash:
-          (raw.transactionHash as string | undefined) ??
-          (raw.transaction_hash as string | undefined),
-      };
+      const paymentData = normalizePaymentResponse(data);
 
       pollingBackoffRef.current = 3000;
       reconnectBackoffRef.current = 1000;


### PR DESCRIPTION
close #617

Description
Added normalizePaymentResponse in src/hooks/usePaymentStatus.ts to map nested merchant_branding and legacy top-level fields into the Payment model (logo URL, normalized hex accent, merchant name, and existing status fields).
Updated fetchPayment in usePaymentStatus to use normalizePaymentResponse so branding is available after the non-blocking initial payment fetch.
Made merchant logos accessible and testable in src/components/checkout/CheckoutBrandingShell.tsx by adding descriptive alt text while preserving the monogram fallback and CSS custom property --checkout-accent usage.
Added unit tests: src/hooks/usePaymentStatus.test.tsx to validate normalization of merchant_branding and legacy fallbacks, and src/components/checkout/__tests__/CheckoutBrandingShell.test.tsx to verify logo, merchant name, and accent CSS variable behavior.

Testing
Ran targeted unit tests with pnpm --dir fluxapay_frontend exec vitest run src/hooks/usePaymentStatus.test.tsx src/components/checkout/__tests__/CheckoutBrandingShell.test.tsx and both test files passed.
Ran eslint against updated files with pnpm --dir fluxapay_frontend exec eslint ... which completed successfully for the changed files.
Ran tsc --noEmit with pnpm --dir fluxapay_frontend exec tsc --noEmit which failed due to pre-existing TypeScript syntax errors in src/lib/api.ts outside the scope of these changes; the failure is unrelated to the edits in this PR.