### PR TITLE
fix for Status-Filtered Composite Indexes  closes #718

### DIFF
--- a/fluxapay_backend/docs/DATABASE_INDEXES.md
+++ b/fluxapay_backend/docs/DATABASE_INDEXES.md
@@ -212,13 +212,17 @@ ORDER BY idx_scan DESC;
    SELECT * FROM pg_stat_user_indexes WHERE idx_blks_read > 0;
    ```
 
-## Future Optimizations
+## Status-Filtered Composite Indexes
 
-### Additional Indexes to Consider
+**Issue Reference**: Issue #718 - [Performance] [Backend] Add Status-Filtered Composite Indexes for Payments, Invoices, and Webhooks
 
-1. **Payment Status Index**: `(merchantId, status, createdAt DESC)` - for status-filtered queries
-2. **Invoice Status Index**: `(merchantId, status, created_at DESC)` - for status-filtered queries
-3. **WebhookLog Status Index**: `(merchantId, status, created_at DESC)` - for status-filtered queries
+The merchant dashboard and API routes frequently filter by payment/invoice/webhook status (e.g., searching only for pending or confirmed payments) in addition to sorting by merchant and creation date. The following composite indexes were added to cover that pattern:
+
+1. **Payment**: `Payment_merchantId_status_createdAt_idx` — `(merchantId, status, createdAt DESC)`
+2. **Invoice**: `Invoice_merchantId_status_created_at_idx` — `(merchantId, status, created_at DESC)`
+3. **WebhookLog**: `WebhookLog_merchantId_status_created_at_idx` — `(merchantId, status, created_at DESC)`
+
+The Payment and Invoice indexes were introduced in `prisma/migrations/20260424000000_add_performance_indexes/migration.sql`. The WebhookLog index was added in `prisma/migrations/20260628000000_add_webhooklog_status_composite_index/migration.sql`, replacing the narrower `WebhookLog_merchantId_status_idx` index since the new composite index already covers `(merchantId, status)` lookups.
 
 ### Partial Indexes
 

--- a/fluxapay_backend/prisma/migrations/20260628000000_add_webhooklog_status_composite_index/migration.sql
+++ b/fluxapay_backend/prisma/migrations/20260628000000_add_webhooklog_status_composite_index/migration.sql
@@ -1,0 +1,6 @@
+-- Replace the merchantId+status index with a status-aware composite index
+-- that also covers created_at ordering, matching the Payment/Invoice pattern.
+DROP INDEX IF EXISTS "WebhookLog_merchantId_status_idx";
+
+CREATE INDEX "WebhookLog_merchantId_status_created_at_idx"
+  ON "WebhookLog"("merchantId", "status", "created_at" DESC);

--- a/fluxapay_backend/prisma/schema.prisma
+++ b/fluxapay_backend/prisma/schema.prisma
@@ -326,7 +326,7 @@ model WebhookLog {
   retryAttempts   WebhookRetryAttempt[]
 
   @@index([merchantId, created_at(sort: Desc)])
-  @@index([merchantId, status])
+  @@index([merchantId, status, created_at(sort: Desc)])
   @@index([status, failed_at])
 }
 


### PR DESCRIPTION

please note that Composite index for Payment and invoices already exists in our schema at line 409 and 469 respectively 

check 
Payment: @@index([merchantId, status, createdAt(sort: Desc)])
Invoice: @@index([merchantId, status, created_at(sort: Desc)])

fix and ran the dev migration for WebhookLog  @@index([merchantId, status, created_at(sort: Desc)])

closes #718 

