### PR TITLE
fix: resolve Stellar backend regressions and API SW caching crash

### DIFF
--- a/fluxapay_backend/src/services/SorobanService.ts
+++ b/fluxapay_backend/src/services/SorobanService.ts
@@ -106,8 +106,6 @@ export class SorobanService {
                 .setTimeout(30)
                 .build();
 
-            txn.sign(this.oracleKeypair);
-
             // 1. Simulation
             const simulation = await this.rpcServer.simulateTransaction(txn);
             if (!rpc.Api.isSimulationSuccess(simulation)) {
@@ -115,14 +113,18 @@ export class SorobanService {
                 return false;
             }
 
-            // 2. Submission
-            const response = await this.rpcServer.sendTransaction(txn);
+            // 2. Assemble resources from simulation, then sign
+            const preparedTxn = rpc.assembleTransaction(txn, simulation).build();
+            preparedTxn.sign(this.oracleKeypair);
+
+            // 3. Submission
+            const response = await this.rpcServer.sendTransaction(preparedTxn);
             if (response.status !== 'PENDING') {
                 console.error('Soroban transaction submission failed:', response);
                 return false;
             }
 
-            // 3. Polling for transaction status
+            // 4. Polling for transaction status
             let txResult = await this.rpcServer.getTransaction(response.hash);
             let attempts = 0;
             while (txResult.status === 'NOT_FOUND' || txResult.status === 'SUCCESS' && (txResult as any).resultMetaXdr === undefined) {
@@ -138,7 +140,7 @@ export class SorobanService {
                 return false;
             }
 
-            // 4. Verify contract state update reflects confirmed
+            // 5. Verify contract state update reflects confirmed
             const verified = await this.verifyContractState(paymentId);
             if (verified) {
                 recordSorobanSuccess();

--- a/fluxapay_backend/src/services/paymentMonitor.service.ts
+++ b/fluxapay_backend/src/services/paymentMonitor.service.ts
@@ -142,7 +142,7 @@ export async function runPaymentMonitorTick(): Promise<void> {
       // Use cursor (last_paging_token) to only fetch transactions newer than last seen
       let paymentsQuery = getServer().payments()
         .forAccount(address)
-        .order('desc')
+        .order('asc')
         .limit(10);
 
       if (payment.last_paging_token) {

--- a/fluxapay_backend/src/services/sweep.service.ts
+++ b/fluxapay_backend/src/services/sweep.service.ts
@@ -143,6 +143,13 @@ export class SweepService {
 
         if (params.mergeDestination) {
           builder.addOperation(
+            Operation.changeTrust({
+              asset: this.usdcAsset,
+              limit: "0",
+            }),
+          );
+
+          builder.addOperation(
             Operation.accountMerge({
               destination: params.mergeDestination,
             }),

--- a/fluxapay_frontend/public/sw.js
+++ b/fluxapay_frontend/public/sw.js
@@ -52,7 +52,7 @@ self.addEventListener('fetch', (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
-  if (url.pathname.startsWith('/api/')) {
+  if (url.pathname.startsWith('/api/') && request.method === 'GET') {
     event.respondWith(networkFirst(request));
     return;
   }


### PR DESCRIPTION
This PR applies focused fixes for four production-impacting issues:

- Soroban verify flow now assembles simulation resources before signing/submitting.
- Sweep merge flow now removes USDC trustline before account merge.
- Horizon payment polling now uses ascending order with cursor for forward pagination.
- Service worker now applies API caching only to GET requests.

### Files changed
- fluxapay_backend/src/services/SorobanService.ts
- fluxapay_backend/src/services/sweep.service.ts
- fluxapay_backend/src/services/paymentMonitor.service.ts
- fluxapay_frontend/public/sw.js

Closes #717
Closes #716
Closes #715
Closes #714