### PR TITLE
[621] [Frontend] Checkout page lacks accessibility: missing ARIA labels on payment amount and address fields

### DIFF
--- a/fluxapay_frontend/src/app/checkout/[charge_id]/page.tsx
+++ b/fluxapay_frontend/src/app/checkout/[charge_id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -12,51 +12,11 @@ import { PaymentTimer } from '@/components/checkout/PaymentTimer';
 import { PaymentStatus } from '@/components/checkout/PaymentStatus';
 import { StellarPayButton } from '@/components/checkout/StellarPayButton';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { CopyField } from '@/components/checkout/CopyField';
 import {
   CheckoutBrandingShell,
   DEFAULT_ACCENT,
 } from '@/components/checkout/CheckoutBrandingShell';
-
-// Re-usable CopyField — inline since it's tightly coupled with checkout
-function CopyField({
-  label,
-  value,
-  truncate,
-  required,
-}: {
-  label: string;
-  value: string;
-  truncate?: boolean;
-  required?: boolean;
-}) {
-  const [copied, setCopied] = useState(false);
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <div className="rounded-lg border bg-gray-50 p-3">
-      <div className="flex items-center justify-between mb-1">
-        <p className="text-xs font-medium text-gray-500">
-          {label}
-          {required && <span className="text-red-500 ml-1">*Required</span>}
-        </p>
-        <button
-          onClick={handleCopy}
-          className="text-xs font-medium text-[color:var(--checkout-accent)] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--checkout-accent)] rounded"
-          aria-label={`Copy ${label}`}
-        >
-          {copied ? '✓ Copied' : 'Copy'}
-        </button>
-      </div>
-      <p className={`font-mono text-sm break-all ${truncate ? 'truncate' : ''}`}>
-        {value}
-      </p>
-    </div>
-  );
-}
 
 /**
  * Hosted checkout page at /checkout/[charge_id]
@@ -255,9 +215,9 @@ export default function CheckoutPage() {
             <p className="mb-6 text-sm text-gray-500">{t('checkout.contactMerchantResolve')}</p>
             {/* Allow top-up: show address again */}
             <div className="mx-auto max-w-md space-y-4 text-left">
-              <CopyField label="Payment Address" value={payment.address} truncate />
+              <CopyField label="Payment Address" value={payment.address} truncate copyAriaLabel="Copy deposit address" fieldId="deposit-address-partial" />
               {payment.memo && (
-                <CopyField label={`Memo (${payment.memoType?.replace('MEMO_', '') || 'TEXT'})`} value={payment.memo} required={payment.memoRequired} />
+                <CopyField label={`Memo (${payment.memoType?.replace('MEMO_', '') || 'TEXT'})`} value={payment.memo} required={payment.memoRequired} copyAriaLabel="Copy memo" fieldId="payment-memo-partial" />
               )}
             </div>
             <div className="mt-6">
@@ -325,7 +285,7 @@ export default function CheckoutPage() {
             </div>
 
             {/* Amount display with fiat equivalent */}
-            <div className="mb-8 text-center" aria-label={`${t('checkout.amountToPay')}: ${payment.amount} ${payment.currency}`}>
+            <div className="mb-8 text-center" role="region" aria-label={`Payment amount: ${payment.amount} ${payment.currency}`}>
               <p className="mb-2 text-sm text-gray-500">{t('checkout.amountToPay')}</p>
               <p className="text-3xl font-bold text-gray-900 sm:text-4xl">
                 {payment.amount} {payment.currency}
@@ -351,12 +311,14 @@ export default function CheckoutPage() {
 
             {/* Copy fields */}
             <div className="mb-8 space-y-4">
-              <CopyField label="Payment Address" value={payment.address} truncate />
+              <CopyField label="Payment Address" value={payment.address} truncate copyAriaLabel="Copy deposit address" fieldId="deposit-address" />
               {payment.memo && (
                 <CopyField
                   label={`Memo (${payment.memoType?.replace('MEMO_', '') || 'TEXT'})`}
                   value={payment.memo}
                   required={payment.memoRequired}
+                  copyAriaLabel="Copy memo"
+                  fieldId="payment-memo"
                 />
               )}
             </div>

--- a/fluxapay_frontend/src/app/pay/[payment_id]/page.tsx
+++ b/fluxapay_frontend/src/app/pay/[payment_id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -19,46 +19,7 @@ import {
   DEFAULT_ACCENT,
 } from '@/components/checkout/CheckoutBrandingShell';
 import { FiatEquivalent } from '@/components/checkout/FiatEquivalent';
-
-function CopyField({
-  label,
-  value,
-  truncate,
-  required,
-}: {
-  label: string;
-  value: string;
-  truncate?: boolean;
-  required?: boolean;
-}) {
-  const [copied, setCopied] = useState(false);
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <div className="rounded-lg border bg-gray-50 p-3">
-      <div className="flex items-center justify-between mb-1">
-        <p className="text-xs font-medium text-gray-500">
-          {label}
-          {required && <span className="text-red-500 ml-1">*Required</span>}
-        </p>
-        <button
-          onClick={handleCopy}
-          className="text-xs font-medium text-[color:var(--checkout-accent)] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--checkout-accent)] rounded"
-          aria-label={`Copy ${label}`}
-        >
-          {copied ? '✓ Copied' : 'Copy'}
-        </button>
-      </div>
-      <p className={`font-mono text-sm break-all ${truncate ? 'truncate' : ''}`}>
-        {value}
-      </p>
-    </div>
-  );
-}
+import { CopyField } from '@/components/checkout/CopyField';
 
 /**
  * Main checkout page for FluxaPay payment gateway
@@ -406,7 +367,8 @@ export default function CheckoutPage() {
 
             <div
               className="mb-8 text-center"
-              aria-label={`${t('checkout.amountToPay')}: ${payment.amount} ${payment.currency}`}
+              role="region"
+              aria-label={`Payment amount: ${payment.amount} ${payment.currency}`}
             >
               <p className="mb-2 text-sm text-gray-500">{t('checkout.amountToPay')}</p>
               <p className="text-3xl font-bold text-gray-900 sm:text-4xl">
@@ -429,13 +391,21 @@ export default function CheckoutPage() {
             </div>
 
             <div className="mb-8 space-y-4">
-              <CopyField label="Payment Address" value={payment.address} truncate />
+              <CopyField
+                label="Payment Address"
+                value={payment.address}
+                truncate
+                copyAriaLabel="Copy deposit address"
+                fieldId="deposit-address"
+              />
 
               {payment.memo && (
                 <CopyField
                   label={`Memo (${payment.memoType?.replace('MEMO_', '') || 'TEXT'})`}
                   value={payment.memo}
                   required={payment.memoRequired}
+                  copyAriaLabel="Copy memo"
+                  fieldId="payment-memo"
                 />
               )}
             </div>

--- a/fluxapay_frontend/src/components/checkout/CopyField.tsx
+++ b/fluxapay_frontend/src/components/checkout/CopyField.tsx
@@ -9,10 +9,23 @@ interface CopyFieldProps {
   value: string;
   truncate?: boolean;
   required?: boolean;
+  /** Overrides the default `Copy ${label}` aria-label on the copy button */
+  copyAriaLabel?: string;
+  /** Accessible id for the value element; auto-generated when omitted */
+  fieldId?: string;
 }
 
-export function CopyField({ label, value, truncate = false, required = false }: CopyFieldProps) {
+export function CopyField({
+  label,
+  value,
+  truncate = false,
+  required = false,
+  copyAriaLabel,
+  fieldId,
+}: CopyFieldProps) {
   const [copied, setCopied] = useState(false);
+  const valueId = fieldId ?? `copy-field-${label.toLowerCase().replace(/\s+/g, '-')}`;
+  const buttonAriaLabel = copyAriaLabel ?? `Copy ${label}`;
 
   const handleCopy = async () => {
     try {
@@ -33,9 +46,9 @@ export function CopyField({ label, value, truncate = false, required = false }: 
   return (
     <div className="group relative mb-4">
       <div className="mb-1.5 flex items-center justify-between">
-        <label className="text-xs font-bold uppercase tracking-widest text-gray-500">
+        <span id={`${valueId}-label`} className="text-xs font-bold uppercase tracking-widest text-gray-500">
           {label}
-        </label>
+        </span>
         {required && (
           <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-tighter text-amber-700">
             Required
@@ -43,7 +56,12 @@ export function CopyField({ label, value, truncate = false, required = false }: 
         )}
       </div>
       <div className="relative flex items-center overflow-hidden rounded-xl border border-gray-200 bg-gray-50 transition-all hover:border-slate-400">
-        <div className="flex-1 overflow-hidden px-4 py-3 font-mono text-sm text-gray-900">
+        <div
+          id={valueId}
+          className="flex-1 overflow-hidden px-4 py-3 font-mono text-sm text-gray-900"
+          aria-labelledby={`${valueId}-label`}
+          aria-label={`${label}: ${value}`}
+        >
           <span className="block truncate" title={value}>
             {displayValue}
           </span>
@@ -51,16 +69,26 @@ export function CopyField({ label, value, truncate = false, required = false }: 
         <button
           type="button"
           onClick={handleCopy}
-          className="flex h-full items-center justify-center border-l border-gray-200 px-4 py-3 text-gray-500 transition-colors hover:bg-slate-900 hover:text-white"
-          aria-label={`Copy ${label}`}
+          className="flex h-full items-center justify-center border-l border-gray-200 px-4 py-3 text-gray-500 transition-colors hover:bg-slate-900 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--checkout-accent)]"
+          aria-label={buttonAriaLabel}
+          aria-describedby={copied ? `${valueId}-copied` : undefined}
         >
           {copied ? (
-            <Check className="h-4 w-4 animate-in zoom-in" />
+            <Check className="h-4 w-4 animate-in zoom-in" aria-hidden="true" />
           ) : (
-            <Copy className="h-4 w-4" />
+            <Copy className="h-4 w-4" aria-hidden="true" />
           )}
+          <span className="sr-only">{copied ? 'Copied' : buttonAriaLabel}</span>
         </button>
       </div>
+      <span
+        id={`${valueId}-copied`}
+        role="status"
+        aria-live="polite"
+        className="sr-only"
+      >
+        {copied ? 'Copied' : ''}
+      </span>
     </div>
   );
 }

--- a/fluxapay_frontend/src/components/checkout/PaymentQRCode.tsx
+++ b/fluxapay_frontend/src/components/checkout/PaymentQRCode.tsx
@@ -31,20 +31,21 @@ export function PaymentQRCode({ address, amount, memoType, memo, size = 256 }: P
   // Keep existing scheme for compatibility with current wallets
   const stellarUri = `stellar:${address}?${query.toString()}`;
 
+  const qrAltText = `QR code for Stellar payment of ${amount} to deposit address ${address}`;
+
   return (
     <div className="flex flex-col items-center space-y-4">
       {/* QR Code Card */}
-      <div
-        role="img"
-        aria-label={`QR code for Stellar payment of ${amount} to address ${address}`}
-        className="bg-white rounded-lg shadow-lg p-6 flex items-center justify-center"
-      >
+      <div className="bg-white rounded-lg shadow-lg p-6 flex items-center justify-center">
         <QRCodeCanvas
           value={stellarUri}
           size={size}
           level="M"
           includeMargin={true}
           className="rounded"
+          role="img"
+          aria-label={qrAltText}
+          title={qrAltText}
         />
       </div>
 
@@ -63,7 +64,7 @@ export function PaymentQRCode({ address, amount, memoType, memo, size = 256 }: P
             onClick={() => copyToClipboard(address, 'Address')}
             className="shrink-0 inline-flex items-center gap-1 text-xs font-medium hover:opacity-80 transition-opacity"
             style={{ color: 'var(--checkout-accent)' }}
-            aria-label="Copy payment address"
+            aria-label="Copy deposit address"
           >
             <Copy className="w-3 h-3" aria-hidden="true" />
             Copy

--- a/fluxapay_frontend/src/components/checkout/__tests__/CopyField.test.tsx
+++ b/fluxapay_frontend/src/components/checkout/__tests__/CopyField.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { CopyField } from '../CopyField';
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('CopyField', () => {
+  const address = 'GABCDEF123456789STELLARADDRESS';
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('uses custom copy aria-label for deposit address', () => {
+    render(
+      <CopyField
+        label="Payment Address"
+        value={address}
+        copyAriaLabel="Copy deposit address"
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Copy deposit address' }),
+    ).toBeInTheDocument();
+  });
+
+  it('announces Copied via aria-live region after copy', async () => {
+    const user = userEvent.setup();
+    render(
+      <CopyField
+        label="Payment Address"
+        value={address}
+        copyAriaLabel="Copy deposit address"
+        fieldId="deposit-address"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Copy deposit address' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('Copied');
+    });
+  });
+
+  it('exposes the full address value to assistive technologies', () => {
+    render(
+      <CopyField
+        label="Payment Address"
+        value={address}
+        fieldId="deposit-address"
+      />,
+    );
+
+    expect(screen.getByLabelText(`Payment Address: ${address}`)).toBeInTheDocument();
+  });
+});

--- a/fluxapay_frontend/src/components/checkout/__tests__/PaymentQRCode.test.tsx
+++ b/fluxapay_frontend/src/components/checkout/__tests__/PaymentQRCode.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { PaymentQRCode } from '../PaymentQRCode';
+
+vi.mock('qrcode.react', () => ({
+  QRCodeCanvas: (props: Record<string, unknown>) => (
+    <canvas data-testid="qr-canvas" {...props} />
+  ),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+  },
+}));
+
+describe('PaymentQRCode', () => {
+  const address = 'GABCDEF123456789STELLARADDRESS';
+
+  it('renders QR code with descriptive alt text including deposit address', () => {
+    render(<PaymentQRCode address={address} amount={25} />);
+
+    const qr = screen.getByRole('img', {
+      name: `QR code for Stellar payment of 25 to deposit address ${address}`,
+    });
+    expect(qr).toBeInTheDocument();
+  });
+
+  it('uses Copy deposit address aria-label on address copy button', () => {
+    render(<PaymentQRCode address={address} amount={25} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Copy deposit address' }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Added accessible payment amount region with explicit Payment amount aria-label
- Enhanced CopyField with deposit-address copy label, aria-live Copied announcement, and linked value semantics
- Added descriptive QR code alt/aria-label text including the deposit address
- Reused shared CopyField on /pay and /checkout pages
- Added unit tests for CopyField and PaymentQRCode accessibility

## Test plan
- [x] npm test (92 tests passing)
- [x] npm run build

Closes #621

