### PR TITLE
[620] [Frontend] Admin merchants page bulk actions (approve/suspend) lack optimistic UI update

### DIFF
--- a/fluxapay_frontend/src/app/admin/merchants/page.tsx
+++ b/fluxapay_frontend/src/app/admin/merchants/page.tsx
@@ -23,6 +23,7 @@ import {
     FileText,
     ShieldOff,
     ShieldCheck,
+    Loader2,
 } from 'lucide-react';
 import BulkConfirmModal from '@/features/admin/merchants/BulkConfirmModal';
 import toast from 'react-hot-toast';
@@ -50,6 +51,8 @@ const AdminMerchantsPage = () => {
     const [showResetKeyModal, setShowResetKeyModal] = useState<string | null>(null);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [bulkAction, setBulkAction] = useState<'suspend' | 'activate' | null>(null);
+    const [isBulkUpdating, setIsBulkUpdating] = useState(false);
+    const merchantsSnapshotRef = useRef<AdminMerchant[] | null>(null);
     const [showExportMenu, setShowExportMenu] = useState<boolean>(false);
     const [isExporting, setIsExporting] = useState<boolean>(false);
     const [exportProgress, setExportProgress] = useState<number>(0);
@@ -97,6 +100,15 @@ const AdminMerchantsPage = () => {
     };
 
     const getAccountStatusConfig = (status: string): StatusConfig => {
+        if (status === 'pending_verification' || status === 'pending') {
+            return {
+                color: 'text-amber-700',
+                bg: 'bg-amber-50',
+                border: 'border-amber-200',
+                icon: <Loader2 className="w-3 h-3 animate-spin" />,
+            };
+        }
+
         return status === 'active'
             ? {
                 color: 'text-emerald-700',
@@ -181,24 +193,76 @@ const AdminMerchantsPage = () => {
     };
 
     const handleBulkConfirm = async (reason: string) => {
-        if (!bulkAction) return { succeeded: 0, failed: [] };
+        if (!bulkAction || isBulkUpdating) return { succeeded: 0, failed: [] };
+
         const status = bulkAction === 'suspend' ? 'suspended' : 'active';
+        const selectedArray = Array.from(selectedIds);
+        const optimisticStatus = 'pending_verification';
+
+        setIsBulkUpdating(true);
+        merchantsSnapshotRef.current = [...merchants];
+
+        await mutate(
+            (current) => {
+                if (!current) return current;
+                return {
+                    ...current,
+                    merchants: current.merchants.map((merchant) =>
+                        selectedIds.has(merchant.id)
+                            ? { ...merchant, accountStatus: optimisticStatus }
+                            : merchant,
+                    ),
+                };
+            },
+            { revalidate: false },
+        );
+
         try {
             const data = await api.admin.merchants.bulkUpdateStatus(
-                Array.from(selectedIds),
+                selectedArray,
                 status,
                 reason,
             );
-            void mutate();
+
+            await mutate();
+
             setSelectedIds(new Set());
-            return { succeeded: data.succeeded ?? 0, failed: data.failed ?? [] };
+
+            const failed = data.failed ?? [];
+            if (failed.length > 0) {
+                toast.error(`${failed.length} merchant(s) failed to update`);
+            } else {
+                toast.success(
+                    `Successfully ${bulkAction === 'suspend' ? 'suspended' : 'activated'} ${data.succeeded ?? selectedArray.length} merchant(s)`,
+                );
+            }
+
+            return { succeeded: data.succeeded ?? 0, failed };
         } catch (err) {
+            const snapshot = merchantsSnapshotRef.current;
+            if (snapshot) {
+                await mutate(
+                    (current) => (current ? { ...current, merchants: snapshot } : current),
+                    { revalidate: false },
+                );
+            } else {
+                await mutate();
+            }
             toastApiError(err);
-            return { succeeded: 0, failed: Array.from(selectedIds).map(id => ({ id, error: 'Request failed' })) };
+            return {
+                succeeded: 0,
+                failed: selectedArray.map((id) => ({ id, error: 'Request failed' })),
+            };
+        } finally {
+            setIsBulkUpdating(false);
+            merchantsSnapshotRef.current = null;
         }
     };
 
-    const closeBulkModal = () => setBulkAction(null);
+    const closeBulkModal = () => {
+        if (isBulkUpdating) return;
+        setBulkAction(null);
+    };
 
     const resetApiKeys = (id: string) => {
         toast.success(`API keys reset for merchant ${id}`);
@@ -517,16 +581,18 @@ const AdminMerchantsPage = () => {
                         <div className="flex items-center gap-2">
                             <button
                                 onClick={() => setBulkAction('activate')}
-                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-emerald-600 hover:bg-emerald-700 rounded-lg transition-colors"
+                                disabled={isBulkUpdating}
+                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-emerald-600 hover:bg-emerald-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             >
-                                <ShieldCheck className="w-3.5 h-3.5" />
+                                {isBulkUpdating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <ShieldCheck className="w-3.5 h-3.5" />}
                                 Activate
                             </button>
                             <button
                                 onClick={() => setBulkAction('suspend')}
-                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-rose-600 hover:bg-rose-700 rounded-lg transition-colors"
+                                disabled={isBulkUpdating}
+                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-rose-600 hover:bg-rose-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             >
-                                <ShieldOff className="w-3.5 h-3.5" />
+                                {isBulkUpdating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <ShieldOff className="w-3.5 h-3.5" />}
                                 Suspend
                             </button>
                             <button

--- a/fluxapay_frontend/src/features/admin/merchants/BulkConfirmModal.tsx
+++ b/fluxapay_frontend/src/features/admin/merchants/BulkConfirmModal.tsx
@@ -50,7 +50,7 @@ export default function BulkConfirmModal({ count, action, onConfirm, onClose }: 
                     : "This will re-enable payment processing for all selected merchants."}
                 </p>
               </div>
-              <button onClick={onClose} className="p-1 hover:bg-slate-100 rounded-lg">
+              <button onClick={onClose} disabled={loading} className="p-1 hover:bg-slate-100 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed">
                 <X className="w-4 h-4 text-slate-500" />
               </button>
             </div>
@@ -74,7 +74,8 @@ export default function BulkConfirmModal({ count, action, onConfirm, onClose }: 
             <div className="flex justify-end gap-3">
               <button
                 onClick={onClose}
-                className="px-4 py-2 text-sm font-medium text-slate-700 hover:text-slate-900 transition-colors"
+                disabled={loading}
+                className="px-4 py-2 text-sm font-medium text-slate-700 hover:text-slate-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Cancel
               </button>


### PR DESCRIPTION
## Summary
- Apply optimistic pending status on selected merchants when bulk action starts
- Disable bulk action controls and show spinner while request is in-flight
- Revalidate from server on success; rollback snapshot and toast on failure
- Prevent duplicate submissions via disabled state

## Test plan
- [x] npm test (87 tests passing)

Closes #620

