### PR TITLE
[618] [Frontend] No rate limiting or debounce on dashboard search/filter inputs

### DIFF
--- a/fluxapay_frontend/src/app/[locale]/dashboard/invoices/page.tsx
+++ b/fluxapay_frontend/src/app/[locale]/dashboard/invoices/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, Suspense } from "react";
+import { useState, useEffect, useCallback, Suspense } from "react";
 import { Invoice, InvoiceStatus } from "@/features/dashboard/invoices/invoices-mock";
 import { InvoicesTable } from "@/features/dashboard/invoices/InvoicesTable";
 import { InvoiceDetails } from "@/features/dashboard/invoices/InvoiceDetails";
@@ -12,6 +12,7 @@ import { api, ApiError } from "@/lib/api";
 import toast from "react-hot-toast";
 import { DataTableCard, ListPageFilterBar, TablePaginationBar } from "@/components/data-table";
 import Input from "@/components/Input";
+import { useDebounce } from "@/hooks/useDebounce";
 
 const PAGE_SIZE = 20;
 const ALL_STATUSES = ["all", "pending", "paid", "cancelled", "overdue"] as const;
@@ -48,8 +49,7 @@ function mapBackendInvoice(row: Record<string, unknown>): Invoice {
 function InvoicesContent() {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
-  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debouncedSearch = useDebounce(search, 300);
   const [statusFilter, setStatusFilter] = useState("all");
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -57,14 +57,6 @@ function InvoicesContent() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
-
-  useEffect(() => {
-    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
-    searchDebounceRef.current = setTimeout(() => setDebouncedSearch(search), 400);
-    return () => {
-      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
-    };
-  }, [search]);
 
   useEffect(() => {
     setPage(1);

--- a/fluxapay_frontend/src/app/[locale]/dashboard/payments/page.tsx
+++ b/fluxapay_frontend/src/app/[locale]/dashboard/payments/page.tsx
@@ -136,15 +136,10 @@ function PaymentsContent() {
     { id: string; url: string; amount: number; currency: string; description?: string; createdAt: string }[]
   >([]);
   const { exportData, exportingFormat } = useMerchantDataExport();
-
-  // Debounce search
-  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const fetchAbortRef = useRef<AbortController | null>(null);
 
   const handleSearchChange = useCallback((value: string) => {
     setSearch(value);
-    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
-    searchDebounceRef.current = setTimeout(() => setDebouncedSearch(value), 400);
   }, []);
 
   // Real-time payment updates via SSE
@@ -173,6 +168,10 @@ function PaymentsContent() {
   });
 
   const fetchPayments = useCallback(async () => {
+    fetchAbortRef.current?.abort();
+    const controller = new AbortController();
+    fetchAbortRef.current = controller;
+
     setLoading(true);
     setLoadError(null);
     try {
@@ -181,28 +180,39 @@ function PaymentsContent() {
         limit: PAGE_SIZE,
         status: statusFilter,
         currency: currencyFilter,
-        search: debouncedSearch || undefined,
+        search: search || undefined,
         date_from: dateFrom || undefined,
         date_to: dateTo || undefined,
-      })) as { data: BackendPayment[]; meta: { total: number } };
+      }, { signal: controller.signal })) as { data: BackendPayment[]; meta: { total: number } };
       setPayments(result.data.map(mapBackendPayment));
       setTotal(result.meta.total);
-    } catch {
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
       const msg = "Failed to load payments.";
       setLoadError(msg);
       toast.error(msg);
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
     }
-  }, [page, statusFilter, currencyFilter, debouncedSearch, dateFrom, dateTo]);
+  }, [page, statusFilter, currencyFilter, search, dateFrom, dateTo]);
 
   useEffect(() => {
     setPage(1);
-  }, [statusFilter, currencyFilter, debouncedSearch, dateFrom, dateTo, amountMin, amountMax]);
+  }, [statusFilter, currencyFilter, search, dateFrom, dateTo, amountMin, amountMax]);
 
   useEffect(() => {
     fetchPayments();
   }, [fetchPayments]);
+
+  useEffect(() => {
+    return () => {
+      fetchAbortRef.current?.abort();
+    };
+  }, []);
 
   const handleRowClick = useCallback((payment: Payment) => {
     setDrawerPayment(payment);
@@ -221,7 +231,7 @@ function PaymentsContent() {
       filters: {
         status: statusFilter,
         currency: currencyFilter,
-        search: debouncedSearch || undefined,
+        search: search || undefined,
         date_from: dateFrom || undefined,
         date_to: dateTo || undefined,
         amount_min: amountMin || undefined,

--- a/fluxapay_frontend/src/features/dashboard/payments/PaymentsFilters.tsx
+++ b/fluxapay_frontend/src/features/dashboard/payments/PaymentsFilters.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/Button";
 import { Search, Save, XCircle } from "lucide-react";
 import { memo, useCallback, useEffect, useState, type ChangeEvent } from "react";
 import toast from "react-hot-toast";
+import { useDebounce } from "@/hooks/useDebounce";
 
 interface PaymentsFiltersProps {
     searchValue: string;
@@ -51,6 +52,26 @@ export const PaymentsFilters = memo(({
 }: PaymentsFiltersProps) => {
     const [presets, setPresets] = useState<SavedPreset[]>([]);
     const [selectedPresetId, setSelectedPresetId] = useState<string>("default");
+    const [localSearch, setLocalSearch] = useState(searchValue);
+    const debouncedSearch = useDebounce(localSearch, 300);
+    const debouncedAmountMin = useDebounce(amountMin, 300);
+    const debouncedAmountMax = useDebounce(amountMax, 300);
+
+    useEffect(() => {
+        setLocalSearch(searchValue);
+    }, [searchValue]);
+
+    useEffect(() => {
+        onSearchChange(debouncedSearch);
+    }, [debouncedSearch, onSearchChange]);
+
+    useEffect(() => {
+        onAmountMinChange(debouncedAmountMin);
+    }, [debouncedAmountMin, onAmountMinChange]);
+
+    useEffect(() => {
+        onAmountMaxChange(debouncedAmountMax);
+    }, [debouncedAmountMax, onAmountMaxChange]);
 
     // Load presets on mount
     useEffect(() => {
@@ -72,9 +93,9 @@ export const PaymentsFilters = memo(({
     };
 
     const handleSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-        onSearchChange(e.target.value);
+        setLocalSearch(e.target.value);
         setSelectedPresetId("custom");
-    }, [onSearchChange]);
+    }, []);
 
     const handleStatusChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
         onStatusChange(e.target.value);
@@ -110,6 +131,7 @@ export const PaymentsFilters = memo(({
         setSelectedPresetId(id);
         
         if (id === "default") {
+            setLocalSearch("");
             onSearchChange("");
             onStatusChange("all");
             onCurrencyChange("all");
@@ -120,6 +142,7 @@ export const PaymentsFilters = memo(({
 
         const preset = presets.find(p => p.id === id);
         if (preset) {
+            setLocalSearch(preset.search);
             onSearchChange(preset.search);
             onStatusChange(preset.status);
             onCurrencyChange(preset.currency);
@@ -129,6 +152,7 @@ export const PaymentsFilters = memo(({
     };
 
     const handleReset = () => {
+        setLocalSearch("");
         onSearchChange("");
         onStatusChange("all");
         onCurrencyChange("all");
@@ -185,7 +209,7 @@ export const PaymentsFilters = memo(({
                     <Input
                         placeholder="Search by ID, Order ID, or customer..."
                         className="pl-10"
-                        value={searchValue}
+                        value={localSearch}
                         onChange={handleSearchChange}
                     />
                 </div>

--- a/fluxapay_frontend/src/features/webhooks/WebhooksFilters.tsx
+++ b/fluxapay_frontend/src/features/webhooks/WebhooksFilters.tsx
@@ -3,7 +3,7 @@ import { Input } from "@/components/Input";
 import { Select } from "@/components/Select";
 import { Search } from "lucide-react";
 import { memo, useCallback, useState, useEffect } from "react";
-import { useDebounce } from "@/lib/performance";
+import { useDebounce } from "@/hooks/useDebounce";
 
 interface WebhooksFiltersProps {
     onSearchChange: (value: string) => void;

--- a/fluxapay_frontend/src/hooks/__tests__/useDebounce.test.ts
+++ b/fluxapay_frontend/src/hooks/__tests__/useDebounce.test.ts
@@ -1,0 +1,42 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useDebounce } from '../useDebounce';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 300));
+    expect(result.current).toBe('initial');
+  });
+
+  it('updates only once after rapid input changes', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: '' } },
+    );
+
+    rerender({ value: 'p' });
+    rerender({ value: 'pa' });
+    rerender({ value: 'pay' });
+    rerender({ value: 'paym' });
+
+    expect(result.current).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('paym');
+  });
+});

--- a/fluxapay_frontend/src/hooks/useDebounce.ts
+++ b/fluxapay_frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Debounce hook for search inputs and filters.
+ * Delays propagating `value` until `delay` ms have elapsed since the last change.
+ */
+export function useDebounce<T>(value: T, delay: number = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/fluxapay_frontend/src/lib/api.ts
+++ b/fluxapay_frontend/src/lib/api.ts
@@ -582,7 +582,7 @@ export const api = {
       search?: string;
       date_from?: string;
       date_to?: string;
-    }) => {
+    }, init?: RequestInit) => {
       const sp = new URLSearchParams();
       if (params?.page != null) sp.set("page", String(params.page));
       if (params?.limit != null) sp.set("limit", String(params.limit));
@@ -591,7 +591,7 @@ export const api = {
       if (params?.search) sp.set("search", params.search);
       if (params?.date_from) sp.set("date_from", params.date_from);
       if (params?.date_to) sp.set("date_to", params.date_to);
-      return fetchWithAuth(`/api/v1/payments?${sp.toString()}`);
+      return fetchWithAuth(`/api/v1/payments?${sp.toString()}`, init);
     },
 
     getById: (paymentId: string) =>

--- a/fluxapay_frontend/src/lib/performance.ts
+++ b/fluxapay_frontend/src/lib/performance.ts
@@ -2,27 +2,9 @@
  * Performance optimization utilities for React components
  */
 
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
-/**
- * Debounce hook for search inputs and filters
- * Delays execution until after wait milliseconds have elapsed since the last call
- */
-export function useDebounce<T>(value: T, delay: number = 300): T {
-  const [debouncedValue, setDebouncedValue] = React.useState<T>(value);
-
-  React.useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-}
+export { useDebounce } from '@/hooks/useDebounce';
 
 /**
  * Hook to track component render performance


### PR DESCRIPTION
## Summary
- Extracted shared useDebounce hook (300ms) under src/hooks/useDebounce.ts
- Debounced PaymentsFilters search and amount inputs before notifying parent
- Added AbortController to payments list fetch to cancel superseded requests
- Updated invoices page and WebhooksFilters to use shared debounce hook
- Added unit test verifying single debounced update after rapid input

## Test plan
- [x] npm test (89 tests passing)

Closes #618