### PR TITLE
fix: remove predictable default encryption seed and fail loudly if HD…

### DIFF
--- a/fluxapay_backend/src/config/env.config.ts
+++ b/fluxapay_backend/src/config/env.config.ts
@@ -80,6 +80,7 @@ const envSchema = z.object({
     KMS_ENCRYPTION_PASSPHRASE: z.string().optional(),
     KMS_ENCRYPTED_MASTER_SEED: z.string().optional(),
     HD_WALLET_MASTER_SEED: z.string().optional(), // Legacy, deprecated
+    HD_WALLET_SEED: z.string().optional(),
 
     // AWS KMS (conditional - required if KMS_PROVIDER=aws)
     AWS_KMS_KEY_ID: z.string().optional(),
@@ -233,8 +234,8 @@ export function validateEnv(): EnvConfig {
     }
 
     // KMS seed validation
-    if (config.KMS_PROVIDER === 'local' && !config.KMS_ENCRYPTED_MASTER_SEED && !config.HD_WALLET_MASTER_SEED) {
-        conditionalErrors.push('  • KMS_ENCRYPTED_MASTER_SEED or HD_WALLET_MASTER_SEED is required when KMS_PROVIDER=local');
+    if (config.KMS_PROVIDER === 'local' && !config.KMS_ENCRYPTED_MASTER_SEED && !config.HD_WALLET_MASTER_SEED && !config.HD_WALLET_SEED) {
+        conditionalErrors.push('  • KMS_ENCRYPTED_MASTER_SEED, HD_WALLET_MASTER_SEED, or HD_WALLET_SEED is required when KMS_PROVIDER=local');
     }
 
     if (conditionalErrors.length > 0) {

--- a/fluxapay_backend/src/services/depositAddress.service.ts
+++ b/fluxapay_backend/src/services/depositAddress.service.ts
@@ -153,9 +153,16 @@ export class DepositAddressService {
 
   /**
    * Local AES-256-GCM encrypt (used when no KMS encrypt available)
+   * Requires HD_WALLET_SEED to be set — fails loudly if missing.
    */
   private static _localEncrypt(plaintext: string): string {
-    const seed = process.env.HD_WALLET_SEED || "default-hd-key";
+    const seed = process.env.HD_WALLET_SEED;
+    if (!seed) {
+      throw new Error(
+        "HD_WALLET_SEED is required for local encryption. " +
+        "Set it in production or configure a KMS provider with an encrypt() method.",
+      );
+    }
     const key = crypto
       .createHash("sha256")
       .update(seed + ":hd-key-data")


### PR DESCRIPTION
…_WALLET_SEED unset (#846)

Replace the 'default-hd-key' fallback in _localEncrypt with an explicit error when HD_WALLET_SEED is missing. Also update env config validation to require HD_WALLET_SEED when KMS_PROVIDER=local and no other seed is configured.

Closes #846