### PR TITLE
fix(kyc,billing,checkout): magic-byte upload validation, current-price renewals, SSE backoff, response validation

### DIFF
--- a/fluxapay_backend/package.json
+++ b/fluxapay_backend/package.json
@@ -60,6 +60,7 @@
     "ed25519-hd-key": "^1.3.0",
     "express": "^5.2.1",
     "express-validator": "^7.3.1",
+    "file-type": "^16.5.4",
     "helmet": "^8.1.0",
     "ioredis": "^5.11.0",
     "jsonwebtoken": "^9.0.3",

--- a/fluxapay_backend/prisma/migrations/20260727000000_subscription_price_change_tracking/migration.sql
+++ b/fluxapay_backend/prisma/migrations/20260727000000_subscription_price_change_tracking/migration.sql
@@ -1,0 +1,8 @@
+-- Track the plan amount actually applied to each subscription's current
+-- period, so renewals can detect and apply plan price changes instead of
+-- indefinitely reusing whatever was charged historically, and so a
+-- price-increase notice can be sent once, 7 days before the renewal that
+-- would apply it.
+ALTER TABLE "MerchantSubscription"
+  ADD COLUMN "current_period_amount" DECIMAL(65,30),
+  ADD COLUMN "price_change_notice_sent_at" TIMESTAMP(3);

--- a/fluxapay_backend/prisma/schema.prisma
+++ b/fluxapay_backend/prisma/schema.prisma
@@ -210,6 +210,12 @@ model MerchantSubscription {
   current_period_start DateTime
   current_period_end   DateTime
   next_billing_date    DateTime
+  /** Plan amount actually charged/applied for the current period, captured
+   *  fresh from Plan.amount at subscription creation and on every renewal. */
+  current_period_amount        Decimal?
+  /** Set once a price-increase notice email has been sent for the
+   *  upcoming renewal, so the 7-day-prior notice job doesn't resend it. */
+  price_change_notice_sent_at  DateTime?
   created_at           DateTime @default(now())
   updated_at           DateTime @updatedAt
 }

--- a/fluxapay_backend/src/__tests__/services/plan.service.test.ts
+++ b/fluxapay_backend/src/__tests__/services/plan.service.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for plan.service.ts's price-change handling (issue #828).
+ *
+ * Validates that:
+ *  1. processBillingCycle() renews at the plan's *current* amount, not a
+ *     stale value, when the admin has changed the plan's price.
+ *  2. createSubscription() seeds current_period_amount from the plan at
+ *     creation time.
+ *  3. sendUpcomingSubscriptionPriceChangeNotices() emails a merchant when
+ *     their upcoming renewal price increased, and skips when it didn't (or
+ *     a notice was already sent).
+ */
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+const mockPrismaClient = {
+  cronLock: {
+    upsert: jest.fn().mockResolvedValue({}),
+    findUnique: jest.fn(),
+    delete: jest.fn().mockResolvedValue({}),
+  },
+  plan: {
+    findUnique: jest.fn(),
+  },
+  merchantSubscription: {
+    create: jest.fn(),
+    update: jest.fn().mockResolvedValue({}),
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+  },
+};
+
+jest.mock("../../generated/client/client", () => ({
+  PrismaClient: jest.fn(() => mockPrismaClient),
+}));
+
+jest.mock("../../services/webhook.service", () => ({
+  createAndDeliverWebhook: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../services/email.service", () => ({
+  sendSubscriptionPriceChangeNoticeEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import {
+  createSubscription,
+  processBillingCycle,
+  sendUpcomingSubscriptionPriceChangeNotices,
+} from "../../services/plan.service";
+import { sendSubscriptionPriceChangeNoticeEmail } from "../../services/email.service";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Minimal Decimal-like stub matching how Prisma's Decimal is used in plan.service.ts. */
+function decimal(value: number) {
+  return {
+    value,
+    toString: () => String(value),
+    lte(other: { value: number }) {
+      return value <= other.value;
+    },
+  };
+}
+
+const NOW = new Date("2026-07-27T10:00:00.000Z");
+
+function mockLockAcquired(jobName: string) {
+  const lockedBy = `${process.env.HOSTNAME ?? "app"}:${process.pid}`;
+  mockPrismaClient.cronLock.findUnique.mockResolvedValue({
+    job_name: jobName,
+    locked_by: lockedBy,
+    expires_at: new Date(NOW.getTime() + 5 * 60 * 1000),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers().setSystemTime(NOW);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("createSubscription", () => {
+  it("seeds current_period_amount from the plan's amount", async () => {
+    mockPrismaClient.plan.findUnique.mockResolvedValue({
+      id: "plan-1",
+      interval: "monthly",
+      amount: decimal(10),
+    });
+    mockPrismaClient.merchantSubscription.create.mockResolvedValue({
+      id: "sub-1",
+      merchant: { webhook_url: null },
+    });
+
+    await createSubscription({ merchantId: "merchant-1", planId: "plan-1" });
+
+    const createArgs = mockPrismaClient.merchantSubscription.create.mock.calls[0][0];
+    expect(createArgs.data.current_period_amount.value).toBe(10);
+  });
+});
+
+describe("processBillingCycle", () => {
+  it("renews at the plan's current price, not a stale stored amount", async () => {
+    const dueSubscription = {
+      id: "sub-1",
+      merchantId: "merchant-1",
+      planId: "plan-1",
+      plan: { slug: "pro" },
+      next_billing_date: NOW,
+      billing_cycle: "monthly",
+    };
+
+    mockPrismaClient.merchantSubscription.findMany.mockResolvedValue([dueSubscription]);
+    mockPrismaClient.merchantSubscription.findUnique.mockResolvedValue({
+      id: "sub-1",
+      merchantId: "merchant-1",
+      planId: "plan-1",
+      status: "active",
+      next_billing_date: NOW,
+      billing_cycle: "monthly",
+      current_period_amount: decimal(10), // stale amount from before the price change
+      merchant: { webhook_url: null },
+      // The plan's price was changed by an admin from 10 to 15.
+      plan: { slug: "pro", amount: decimal(15) },
+    });
+
+    const result = await processBillingCycle();
+
+    expect(result.renewed).toBe(1);
+    const updateArgs = mockPrismaClient.merchantSubscription.update.mock.calls[0][0];
+    expect(updateArgs.data.current_period_amount.value).toBe(15);
+    // The next price-change window should be re-armed for the following cycle.
+    expect(updateArgs.data.price_change_notice_sent_at).toBeNull();
+  });
+
+  it("skips subscriptions that are no longer active", async () => {
+    mockPrismaClient.merchantSubscription.findMany.mockResolvedValue([
+      { id: "sub-1", merchantId: "m1", planId: "p1", plan: { slug: "pro" }, next_billing_date: NOW, billing_cycle: "monthly" },
+    ]);
+    mockPrismaClient.merchantSubscription.findUnique.mockResolvedValue({
+      id: "sub-1",
+      status: "canceled",
+    });
+
+    const result = await processBillingCycle();
+
+    expect(result.renewed).toBe(0);
+    expect(mockPrismaClient.merchantSubscription.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendUpcomingSubscriptionPriceChangeNotices", () => {
+  beforeEach(() => mockLockAcquired("subscription_price_change_notice"));
+
+  it("emails the merchant when the upcoming renewal price increased", async () => {
+    mockPrismaClient.merchantSubscription.findMany.mockResolvedValue([
+      {
+        id: "sub-1",
+        current_period_amount: decimal(10),
+        next_billing_date: new Date(NOW.getTime() + 3 * 24 * 60 * 60 * 1000),
+        merchant: {
+          email: "merchant@example.com",
+          business_name: "Acme",
+          email_notifications_enabled: true,
+        },
+        plan: { name: "Pro", amount: decimal(15), currency: "USDC" },
+      },
+    ]);
+
+    const result = await sendUpcomingSubscriptionPriceChangeNotices();
+
+    expect(result.notified).toBe(1);
+    expect(sendSubscriptionPriceChangeNoticeEmail).toHaveBeenCalledWith(
+      "merchant@example.com",
+      "Acme",
+      expect.objectContaining({
+        subscription_id: "sub-1",
+        old_amount: "10",
+        new_amount: "15",
+      }),
+    );
+    expect(mockPrismaClient.merchantSubscription.update).toHaveBeenCalledWith({
+      where: { id: "sub-1" },
+      data: { price_change_notice_sent_at: NOW },
+    });
+  });
+
+  it("does not email when the price did not increase", async () => {
+    mockPrismaClient.merchantSubscription.findMany.mockResolvedValue([
+      {
+        id: "sub-2",
+        current_period_amount: decimal(15),
+        next_billing_date: new Date(NOW.getTime() + 3 * 24 * 60 * 60 * 1000),
+        merchant: {
+          email: "merchant2@example.com",
+          business_name: "Beta",
+          email_notifications_enabled: true,
+        },
+        plan: { name: "Pro", amount: decimal(15), currency: "USDC" },
+      },
+    ]);
+
+    const result = await sendUpcomingSubscriptionPriceChangeNotices();
+
+    expect(result.notified).toBe(0);
+    expect(sendSubscriptionPriceChangeNoticeEmail).not.toHaveBeenCalled();
+    expect(mockPrismaClient.merchantSubscription.update).not.toHaveBeenCalled();
+  });
+
+  it("does not email a merchant who has disabled email notifications", async () => {
+    mockPrismaClient.merchantSubscription.findMany.mockResolvedValue([
+      {
+        id: "sub-3",
+        current_period_amount: decimal(10),
+        next_billing_date: new Date(NOW.getTime() + 3 * 24 * 60 * 60 * 1000),
+        merchant: {
+          email: "merchant3@example.com",
+          business_name: "Gamma",
+          email_notifications_enabled: false,
+        },
+        plan: { name: "Pro", amount: decimal(20), currency: "USDC" },
+      },
+    ]);
+
+    const result = await sendUpcomingSubscriptionPriceChangeNotices();
+
+    expect(sendSubscriptionPriceChangeNoticeEmail).not.toHaveBeenCalled();
+    // Still marked as processed so it isn't picked up again every tick.
+    expect(mockPrismaClient.merchantSubscription.update).toHaveBeenCalledWith({
+      where: { id: "sub-3" },
+      data: { price_change_notice_sent_at: NOW },
+    });
+    expect(result.notified).toBe(1);
+  });
+});

--- a/fluxapay_backend/src/services/__tests__/kyc.service.test.ts
+++ b/fluxapay_backend/src/services/__tests__/kyc.service.test.ts
@@ -4,29 +4,57 @@ import {
 } from "../../utils/kycUploadValidation.util";
 import { ErrorCode } from "../../types/errors";
 
+// Minimal real magic-byte fixtures so `file-type` detects the genuine
+// content type, independent of the declared `mimetype` string.
+const JPEG_BYTES = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+]);
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+]);
+const PDF_BYTES = Buffer.from("%PDF-1.4\n%\xe2\xe3\xcf\xd3\n", "binary");
+// Windows PE executable ("MZ") header, disguised with an image/jpeg mimetype.
+const EXE_BYTES = Buffer.from([
+  0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+]);
+const EMPTY_BYTES = Buffer.alloc(0);
+
 describe("KYC upload validation", () => {
-  it("accepts JPEG files", () => {
+  it("accepts JPEG files", async () => {
     expect(
-      validateKycUploadFile({ mimetype: "image/jpeg", size: 1024 }),
+      await validateKycUploadFile({
+        mimetype: "image/jpeg",
+        size: 1024,
+        buffer: JPEG_BYTES,
+      }),
     ).toBeNull();
   });
 
-  it("accepts PNG files", () => {
+  it("accepts PNG files", async () => {
     expect(
-      validateKycUploadFile({ mimetype: "image/png", size: 1024 }),
+      await validateKycUploadFile({
+        mimetype: "image/png",
+        size: 1024,
+        buffer: PNG_BYTES,
+      }),
     ).toBeNull();
   });
 
-  it("accepts PDF files", () => {
+  it("accepts PDF files", async () => {
     expect(
-      validateKycUploadFile({ mimetype: "application/pdf", size: 1024 }),
+      await validateKycUploadFile({
+        mimetype: "application/pdf",
+        size: 1024,
+        buffer: PDF_BYTES,
+      }),
     ).toBeNull();
   });
 
-  it("rejects invalid MIME types with INVALID_FILE_TYPE", () => {
-    const result = validateKycUploadFile({
+  it("rejects invalid MIME types with INVALID_FILE_TYPE", async () => {
+    const result = await validateKycUploadFile({
       mimetype: "image/gif",
       size: 1024,
+      buffer: EMPTY_BYTES,
     });
     expect(result).toEqual({
       status: 422,
@@ -35,19 +63,21 @@ describe("KYC upload validation", () => {
     });
   });
 
-  it("rejects executable MIME types with INVALID_FILE_TYPE", () => {
-    const result = validateKycUploadFile({
+  it("rejects executable MIME types with INVALID_FILE_TYPE", async () => {
+    const result = await validateKycUploadFile({
       mimetype: "application/x-msdownload",
       size: 1024,
+      buffer: EXE_BYTES,
     });
     expect(result?.code).toBe(ErrorCode.INVALID_FILE_TYPE);
     expect(result?.status).toBe(422);
   });
 
-  it("rejects files over 10MB with FILE_TOO_LARGE", () => {
-    const result = validateKycUploadFile({
+  it("rejects files over 10MB with FILE_TOO_LARGE", async () => {
+    const result = await validateKycUploadFile({
       mimetype: "image/jpeg",
       size: KYC_MAX_FILE_SIZE_BYTES + 1,
+      buffer: JPEG_BYTES,
     });
     expect(result).toEqual({
       status: 422,
@@ -56,20 +86,45 @@ describe("KYC upload validation", () => {
     });
   });
 
-  it("accepts files exactly at 10MB limit", () => {
+  it("accepts files exactly at 10MB limit", async () => {
     expect(
-      validateKycUploadFile({
+      await validateKycUploadFile({
         mimetype: "application/pdf",
         size: KYC_MAX_FILE_SIZE_BYTES,
+        buffer: PDF_BYTES,
       }),
     ).toBeNull();
   });
 
-  it("validates by MIME type, not extension", () => {
-    const disguisedExe = validateKycUploadFile({
+  it("validates by MIME type, not extension", async () => {
+    const disguisedExe = await validateKycUploadFile({
       mimetype: "application/x-msdownload",
       size: 500,
+      buffer: EXE_BYTES,
     });
     expect(disguisedExe?.code).toBe(ErrorCode.INVALID_FILE_TYPE);
+  });
+
+  it("rejects a renamed .exe declaring Content-Type: image/jpeg with a 400 magic-byte mismatch", async () => {
+    const result = await validateKycUploadFile({
+      mimetype: "image/jpeg",
+      size: 1024,
+      buffer: EXE_BYTES,
+    });
+    expect(result).toEqual({
+      status: 400,
+      code: ErrorCode.INVALID_FILE_TYPE,
+      message: "File content does not match its declared type.",
+    });
+  });
+
+  it("rejects a PNG disguised as a PDF (magic bytes don't match declared type)", async () => {
+    const result = await validateKycUploadFile({
+      mimetype: "application/pdf",
+      size: 1024,
+      buffer: PNG_BYTES,
+    });
+    expect(result?.status).toBe(400);
+    expect(result?.code).toBe(ErrorCode.INVALID_FILE_TYPE);
   });
 });

--- a/fluxapay_backend/src/services/cron.service.ts
+++ b/fluxapay_backend/src/services/cron.service.ts
@@ -7,6 +7,7 @@
  *  • Settlement batch        – runs daily at 00:00 UTC (swept → fiat payout)
  *  • Payment monitor         – runs every 2 min (on-chain USDC detection)
  *  • Billing cycle           – runs daily at 01:00 UTC (subscription renewals)
+ *  • Price-change notice     – runs daily at 04:00 UTC (warn merchants of upcoming plan price increases)
  *  • Database backup         – runs daily at 02:00 UTC (encrypted SQL dump)
  *  • Invoice overdue check   – runs every hour
  *  • Idempotency cleanup     – runs daily at 03:00 UTC
@@ -14,6 +15,7 @@
  * Environment variables:
  *  SETTLEMENT_CRON           – Cron for settlement (default: "0 0 * * *")
  *  BILLING_CRON              – Cron for subscription billing (default: "0 1 * * *")
+ *  PRICE_CHANGE_NOTICE_CRON  – Cron for subscription price-change notices (default: "0 4 * * *")
  *  DB_BACKUP_CRON            – Cron for database backup (default: "0 2 * * *")
  *  IDEMPOTENCY_CLEANUP_CRON  – Cron for idempotency cleanup (default: "0 3 * * *")
  *  INVOICE_OVERDUE_CRON      – Cron for invoice overdue check (default: "0 * * * *")
@@ -22,7 +24,7 @@
 
 import { schedule, validate, type ScheduledTask } from "node-cron";
 import { runSettlementBatch } from "./settlementBatch.service";
-import { processBillingCycle } from "./plan.service";
+import { processBillingCycle, sendUpcomingSubscriptionPriceChangeNotices } from "./plan.service";
 import { runSweepWithLock } from "./sweepCron.service";
 import { funderMonitorService } from "./funderMonitor.service";
 import { runPaymentExpiryReminderJob } from "./paymentExpiryReminder.service";
@@ -36,6 +38,7 @@ import { acquireCronLock, releaseCronLock } from "../utils/redisLock.util";
 
 const SETTLEMENT_CRON_EXPR = process.env.SETTLEMENT_CRON ?? "0 0 * * *";
 const BILLING_CRON_EXPR = process.env.BILLING_CRON ?? "0 1 * * *";
+const PRICE_CHANGE_NOTICE_CRON_EXPR = process.env.PRICE_CHANGE_NOTICE_CRON ?? "0 4 * * *";
 const SWEEP_CRON_EXPR = getSweepCronInterval();
 const FUNDER_MONITOR_CRON_EXPR = process.env.FUNDER_MONITOR_CRON ?? "*/10 * * * *";
 const CHECKOUT_REMINDER_CRON_EXPR = process.env.CHECKOUT_REMINDER_CRON ?? "*/2 * * * *";
@@ -47,6 +50,7 @@ const ADDRESS_POOL_CRON_EXPR = process.env.ADDRESS_POOL_CRON ?? "*/10 * * * *";
 
 let settlementTask: ScheduledTask | null = null;
 let billingTask: ScheduledTask | null = null;
+let priceChangeNoticeTask: ScheduledTask | null = null;
 let sweepTask: ScheduledTask | null = null;
 let funderMonitorTask: ScheduledTask | null = null;
 let checkoutReminderTask: ScheduledTask | null = null;
@@ -98,6 +102,26 @@ export function startCronJobs(): void {
       console.error(`[Cron] ❌ Billing cycle failed: ${err.message}`);
     } finally {
       await releaseCronLock("billing");
+    }
+  }, { timezone: "UTC" });
+
+  // ── Subscription price-change notice ──────────────────────────────────────
+  priceChangeNoticeTask = schedule(PRICE_CHANGE_NOTICE_CRON_EXPR, async () => {
+    console.log(`[Cron] ⏰ Price-change notice triggered at ${new Date().toISOString()}`);
+    const acquired = await acquireCronLock("price_change_notice");
+    if (!acquired) {
+      console.warn(`[Cron] ⚠️ Price-change notice lock held by another instance – skipping tick.`);
+      return;
+    }
+    try {
+      const result = await sendUpcomingSubscriptionPriceChangeNotices();
+      if (result.processed > 0) {
+        console.log(`[Cron] ✅ Price-change notice — ${result.notified}/${result.processed} notified.`);
+      }
+    } catch (err: any) {
+      console.error(`[Cron] ❌ Price-change notice job failed: ${err.message}`);
+    } finally {
+      await releaseCronLock("price_change_notice");
     }
   }, { timezone: "UTC" });
 
@@ -263,6 +287,7 @@ export function stopCronJobs(): void {
   const tasks: [ScheduledTask | null, string][] = [
     [settlementTask, "Settlement batch"],
     [billingTask, "Billing cycle"],
+    [priceChangeNoticeTask, "Price-change notice"],
     [sweepTask, "Sweep"],
     [funderMonitorTask, "Funder monitor"],
     [checkoutReminderTask, "Checkout reminder"],
@@ -280,6 +305,7 @@ export function stopCronJobs(): void {
   }
   settlementTask = null;
   billingTask = null;
+  priceChangeNoticeTask = null;
   sweepTask = null;
   funderMonitorTask = null;
   checkoutReminderTask = null;

--- a/fluxapay_backend/src/services/email.service.ts
+++ b/fluxapay_backend/src/services/email.service.ts
@@ -179,6 +179,56 @@ export async function sendCheckoutExpiryReminderEmail(
   }
 }
 
+export interface PriceChangeNoticeDetails {
+  subscription_id: string;
+  plan_name: string;
+  old_amount: string;
+  new_amount: string;
+  currency: string;
+  renewal_date: string;
+}
+
+export async function sendSubscriptionPriceChangeNoticeEmail(
+  to: string,
+  businessName: string,
+  details: PriceChangeNoticeDetails,
+) {
+  try {
+    await sendIfNotSuppressed(to, async () => {
+    const response = await getResend().emails.send({
+      from: process.env.MAIL_FROM || "noreply@fluxapay.com",
+      to,
+      subject: `Your ${escapeHtml(details.plan_name)} plan price is changing`,
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+          <h2>Upcoming Price Change</h2>
+          <p>Hello ${escapeHtml(businessName)},</p>
+          <p>Your <strong>${escapeHtml(details.plan_name)}</strong> subscription will renew at a new price starting <strong>${escapeHtml(new Date(details.renewal_date).toLocaleDateString())}</strong>.</p>
+          <div style="background: #fff8e1; border-left: 4px solid #f59e0b; padding: 16px; border-radius: 4px; margin: 16px 0;">
+            <table style="width: 100%; border-collapse: collapse;">
+              <tr><td style="padding: 6px 0;"><strong>Current price:</strong></td><td>${escapeHtml(details.old_amount)} ${escapeHtml(details.currency)}</td></tr>
+              <tr><td style="padding: 6px 0;"><strong>New price:</strong></td><td>${escapeHtml(details.new_amount)} ${escapeHtml(details.currency)}</td></tr>
+              <tr><td style="padding: 6px 0;"><strong>Effective:</strong></td><td>${escapeHtml(new Date(details.renewal_date).toLocaleDateString())}</td></tr>
+              <tr><td style="padding: 6px 0;"><strong>Subscription ID:</strong></td><td style="font-family: monospace; font-size: 12px;">${escapeHtml(details.subscription_id)}</td></tr>
+            </table>
+          </div>
+          <p style="color: #666; font-size: 13px;">No action is needed if you'd like to continue at the new price. Contact support if you have questions.</p>
+          <p>— The FluxaPay Team</p>
+          ${buildUnsubscribeFooter(to)}
+        </div>
+      `,
+    });
+    if (response.error) {
+      if (isDevEnv()) console.error("Error sending price change notice email:", response.error);
+      throw new Error("Failed to send price change notice email");
+    }
+    });
+  } catch (err) {
+    if (isDevEnv()) console.error("Error sending price change notice email:", err);
+    throw err;
+  }
+}
+
 export interface PaymentConfirmationDetails {
   amount: string;
   currency: string;

--- a/fluxapay_backend/src/services/kyc.service.ts
+++ b/fluxapay_backend/src/services/kyc.service.ts
@@ -123,7 +123,7 @@ export async function uploadKycDocumentService(
     throw apiError(413, ErrorCode.FILE_TOO_LARGE, "File size exceeds 10MB limit");
   }
 
-  const validationError = validateKycUploadFile(file);
+  const validationError = await validateKycUploadFile(file);
   if (validationError) {
     throw validationError;
   }

--- a/fluxapay_backend/src/services/plan.service.ts
+++ b/fluxapay_backend/src/services/plan.service.ts
@@ -10,8 +10,13 @@
 import { Decimal } from "@prisma/client/runtime/library";
 import { PrismaClient } from "../generated/client/client";
 import { createAndDeliverWebhook } from "./webhook.service";
+import { sendSubscriptionPriceChangeNoticeEmail } from "./email.service";
 
 const prisma = new PrismaClient();
+
+const PRICE_CHANGE_NOTICE_LOCK = "subscription_price_change_notice";
+const PRICE_CHANGE_NOTICE_LOCK_TTL_MS = 5 * 60 * 1000;
+const PRICE_CHANGE_NOTICE_WINDOW_DAYS = 7;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -128,6 +133,7 @@ export async function createSubscription(params: {
       current_period_start: now,
       current_period_end: periodEnd,
       next_billing_date: nextBilling,
+      current_period_amount: plan.amount,
     },
     include: { merchant: true, plan: true },
   });
@@ -202,12 +208,19 @@ export async function processBillingCycle(): Promise<ProcessBillingCycleResult> 
       );
       const nextBilling = new Date(periodEnd);
 
+      // Always charge the plan's *current* amount, not whatever was stored
+      // from a previous period -- an admin price change must take effect
+      // on the very next renewal rather than being silently ignored.
       await prisma.merchantSubscription.update({
         where: { id: sub.id },
         data: {
           current_period_start: periodStart,
           current_period_end: periodEnd,
           next_billing_date: nextBilling,
+          current_period_amount: subscription.plan.amount,
+          // Reset so a further price change ahead of the *next* renewal
+          // gets its own notice.
+          price_change_notice_sent_at: null,
         },
       });
 
@@ -238,4 +251,117 @@ export async function processBillingCycle(): Promise<ProcessBillingCycleResult> 
     renewed,
     errors,
   };
+}
+
+// ─── Upcoming price-change notices ─────────────────────────────────────────────
+
+export interface PriceChangeNoticeResult {
+  processed: number;
+  notified: number;
+  errors: { subscriptionId: string; error: string }[];
+}
+
+async function acquirePriceChangeNoticeLock(lockedBy: string): Promise<boolean> {
+  const now = new Date();
+  try {
+    await prisma.cronLock.upsert({
+      where: { job_name: PRICE_CHANGE_NOTICE_LOCK },
+      create: {
+        job_name: PRICE_CHANGE_NOTICE_LOCK,
+        locked_at: now,
+        expires_at: new Date(now.getTime() + PRICE_CHANGE_NOTICE_LOCK_TTL_MS),
+        locked_by: lockedBy,
+      },
+      update: {
+        locked_at: now,
+        expires_at: new Date(now.getTime() + PRICE_CHANGE_NOTICE_LOCK_TTL_MS),
+        locked_by: lockedBy,
+      },
+    });
+    const lock = await prisma.cronLock.findUnique({ where: { job_name: PRICE_CHANGE_NOTICE_LOCK } });
+    return lock?.locked_by === lockedBy && lock.expires_at > now;
+  } catch {
+    return false;
+  }
+}
+
+async function releasePriceChangeNoticeLock(): Promise<void> {
+  await prisma.cronLock
+    .delete({ where: { job_name: PRICE_CHANGE_NOTICE_LOCK } })
+    .catch(() => {/* already gone */});
+}
+
+/**
+ * Find active subscriptions renewing within the next 7 days whose plan's
+ * current amount differs from what was actually charged last period, and
+ * email the merchant a heads-up before that new price takes effect.
+ * Idempotent via `price_change_notice_sent_at`; call this from a daily cron.
+ */
+export async function sendUpcomingSubscriptionPriceChangeNotices(): Promise<PriceChangeNoticeResult> {
+  const result: PriceChangeNoticeResult = { processed: 0, notified: 0, errors: [] };
+
+  const lockedBy = `${process.env.HOSTNAME ?? "app"}:${process.pid}`;
+  const acquired = await acquirePriceChangeNoticeLock(lockedBy);
+  if (!acquired) {
+    console.log("[PlanService] Price-change notice lock held by another instance — skipping.");
+    return result;
+  }
+
+  try {
+    const now = new Date();
+    const windowEnd = new Date(
+      now.getTime() + PRICE_CHANGE_NOTICE_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    const candidates = await prisma.merchantSubscription.findMany({
+      where: {
+        status: "active",
+        next_billing_date: { gt: now, lte: windowEnd },
+        price_change_notice_sent_at: null,
+      },
+      include: { merchant: true, plan: true },
+    });
+
+    result.processed = candidates.length;
+
+    for (const sub of candidates) {
+      try {
+        const oldAmount = sub.current_period_amount;
+        const newAmount = sub.plan.amount;
+
+        // Only notify when the plan price actually increased -- a decrease
+        // or an unchanged price needs no advance warning.
+        if (oldAmount === null || newAmount.lte(oldAmount)) continue;
+
+        if (sub.merchant.email_notifications_enabled) {
+          await sendSubscriptionPriceChangeNoticeEmail(
+            sub.merchant.email,
+            sub.merchant.business_name,
+            {
+              subscription_id: sub.id,
+              plan_name: sub.plan.name,
+              old_amount: oldAmount.toString(),
+              new_amount: newAmount.toString(),
+              currency: sub.plan.currency,
+              renewal_date: sub.next_billing_date.toISOString(),
+            },
+          );
+        }
+
+        await prisma.merchantSubscription.update({
+          where: { id: sub.id },
+          data: { price_change_notice_sent_at: now },
+        });
+
+        result.notified++;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        result.errors.push({ subscriptionId: sub.id, error: msg });
+      }
+    }
+  } finally {
+    await releasePriceChangeNoticeLock();
+  }
+
+  return result;
 }

--- a/fluxapay_backend/src/utils/kycUploadValidation.util.ts
+++ b/fluxapay_backend/src/utils/kycUploadValidation.util.ts
@@ -1,3 +1,4 @@
+import { fromBuffer } from "file-type";
 import { apiError, ApiErrorPayload } from "../helpers/apiError.helper";
 import { ErrorCode } from "../types/errors";
 
@@ -9,10 +10,17 @@ export const KYC_ALLOWED_MIME_TYPES = [
 
 export const KYC_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
-export function validateKycUploadFile(file: {
+/**
+ * Validates a KYC upload. In addition to the declared `mimetype`/`size`,
+ * this reads the file's actual magic bytes and rejects it if they don't
+ * match the declared type -- a spoofed `Content-Type`/`mimetype` header
+ * alone is not enough to pass validation.
+ */
+export async function validateKycUploadFile(file: {
   mimetype: string;
   size: number;
-}): ApiErrorPayload | null {
+  buffer: Buffer;
+}): Promise<ApiErrorPayload | null> {
   if (!KYC_ALLOWED_MIME_TYPES.includes(file.mimetype as (typeof KYC_ALLOWED_MIME_TYPES)[number])) {
     return apiError(
       422,
@@ -23,6 +31,15 @@ export function validateKycUploadFile(file: {
 
   if (file.size > KYC_MAX_FILE_SIZE_BYTES) {
     return apiError(422, ErrorCode.FILE_TOO_LARGE, "File size exceeds 10MB limit.");
+  }
+
+  const detected = await fromBuffer(file.buffer);
+  if (!detected || !(KYC_ALLOWED_MIME_TYPES as readonly string[]).includes(detected.mime) || detected.mime !== file.mimetype) {
+    return apiError(
+      400,
+      ErrorCode.INVALID_FILE_TYPE,
+      "File content does not match its declared type.",
+    );
   }
 
   return null;

--- a/fluxapay_frontend/package.json
+++ b/fluxapay_frontend/package.json
@@ -42,7 +42,8 @@
     "recharts": "^3.7.0",
     "swr": "^2.4.0",
     "tailwind-merge": "^3.4.0",
-    "yup": "^1.7.1"
+    "yup": "^1.7.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/fluxapay_frontend/src/hooks/usePaymentStatus.test.tsx
+++ b/fluxapay_frontend/src/hooks/usePaymentStatus.test.tsx
@@ -1,7 +1,57 @@
-import { describe, expect, it } from 'vitest';
-import { normalizePaymentResponse } from './usePaymentStatus';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { normalizePaymentResponse, PaymentParseError, usePaymentStatus } from './usePaymentStatus';
 
 describe('normalizePaymentResponse', () => {
+  const VALID_PAYMENT = {
+    id: 'pay_123',
+    amount: 10,
+    currency: 'USDC',
+    address: 'GABCDEF',
+    expiresAt: '2026-06-27T12:00:00.000Z',
+    status: 'pending',
+  };
+
+  it('throws PaymentParseError when a required field is missing (e.g. address)', () => {
+    const { address: _address, ...withoutAddress } = VALID_PAYMENT;
+    expect(() => normalizePaymentResponse(withoutAddress)).toThrow(PaymentParseError);
+    try {
+      normalizePaymentResponse(withoutAddress);
+      throw new Error('expected normalizePaymentResponse to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaymentParseError);
+      expect((err as PaymentParseError).fieldErrors.address).toBeDefined();
+    }
+  });
+
+  it('throws PaymentParseError when amount is missing', () => {
+    const { amount: _amount, ...withoutAmount } = VALID_PAYMENT;
+    expect(() => normalizePaymentResponse(withoutAmount)).toThrow(PaymentParseError);
+  });
+
+  it('throws PaymentParseError when status is not a recognized PaymentStatus', () => {
+    expect(() =>
+      normalizePaymentResponse({ ...VALID_PAYMENT, status: 'not_a_real_status' }),
+    ).toThrow(PaymentParseError);
+  });
+
+  it('throws PaymentParseError when expiresAt is not a parseable date', () => {
+    expect(() =>
+      normalizePaymentResponse({ ...VALID_PAYMENT, expiresAt: 'not-a-date' }),
+    ).toThrow(PaymentParseError);
+  });
+
+  it('throws PaymentParseError on a completely empty response', () => {
+    expect(() => normalizePaymentResponse({})).toThrow(PaymentParseError);
+  });
+
+  it('does not throw for a fully valid response', () => {
+    expect(() => normalizePaymentResponse(VALID_PAYMENT)).not.toThrow();
+    const result = normalizePaymentResponse(VALID_PAYMENT);
+    expect(result.id).toBe('pay_123');
+    expect(result.expiresAt).toEqual(new Date('2026-06-27T12:00:00.000Z'));
+  });
+
   it('maps merchant_branding from charge API responses into checkout branding fields', () => {
     const payment = normalizePaymentResponse({
       id: 'ch_123',
@@ -39,5 +89,148 @@ describe('normalizePaymentResponse', () => {
     expect(payment.checkoutLogoUrl).toBe('https://cdn.example.com/legacy.png');
     expect(payment.checkoutAccentColor).toBe('#3366ff');
     expect(payment.merchantName).toBe('Legacy Store');
+  });
+});
+
+describe('usePaymentStatus SSE reconnect backoff', () => {
+  class MockEventSource {
+    static instances: MockEventSource[] = [];
+    onopen: (() => void) | null = null;
+    onmessage: ((ev: { data: string }) => void) | null = null;
+    onerror: (() => void) | null = null;
+    closed = false;
+    url: string;
+    constructor(url: string) {
+      this.url = url;
+      MockEventSource.instances.push(this);
+    }
+    close() {
+      this.closed = true;
+    }
+  }
+
+  const originalEventSource = (globalThis as { EventSource?: unknown }).EventSource;
+  const originalFetch = globalThis.fetch;
+
+  function mockPaymentFetchResponse() {
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({
+        id: 'pay_1',
+        amount: 10,
+        currency: 'USDC',
+        address: 'GABC',
+        expiresAt: new Date().toISOString(),
+        status: 'pending',
+      }),
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockEventSource.instances = [];
+    (globalThis as { EventSource?: unknown }).EventSource = MockEventSource;
+    (window as { EventSource?: unknown }).EventSource = MockEventSource;
+    globalThis.fetch = vi.fn().mockResolvedValue(mockPaymentFetchResponse()) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    (globalThis as { EventSource?: unknown }).EventSource = originalEventSource;
+    (window as { EventSource?: unknown }).EventSource = originalEventSource;
+    globalThis.fetch = originalFetch;
+  });
+
+  it('retries SSE with exponential backoff (1s, 2s, 4s, 8s, +/-20% jitter) before falling back to polling after 5 failures', async () => {
+    const { result } = renderHook(() => usePaymentStatus('pay_1'));
+
+    // Let the initial fetch resolve and the SSE effect mount its first connection.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(MockEventSource.instances.length).toBe(1);
+
+    const expectedBaseDelays = [1000, 2000, 4000, 8000];
+
+    for (let i = 0; i < expectedBaseDelays.length; i++) {
+      const es = MockEventSource.instances[i];
+      const before = MockEventSource.instances.length;
+
+      act(() => {
+        es.onerror?.();
+      });
+
+      // No new connection until after the backoff delay elapses.
+      expect(MockEventSource.instances.length).toBe(before);
+
+      const base = expectedBaseDelays[i];
+      const minDelay = Math.floor(base * 0.8);
+      const maxDelay = Math.ceil(base * 1.2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(Math.max(minDelay - 1, 0));
+      });
+      expect(MockEventSource.instances.length).toBe(before);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(maxDelay - minDelay + 2);
+      });
+      expect(MockEventSource.instances.length).toBe(before + 1);
+    }
+
+    expect(result.current.connectionType).not.toBe('polling');
+
+    // 5th consecutive failure switches to polling instead of retrying SSE again.
+    const fifth = MockEventSource.instances[4];
+    act(() => {
+      fifth.onerror?.();
+    });
+
+    await waitFor(() => {
+      expect(result.current.connectionType).toBe('polling');
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+    expect(MockEventSource.instances.length).toBe(5);
+  });
+
+  it('resets the backoff and failure count after a successful reconnection', async () => {
+    renderHook(() => usePaymentStatus('pay_1'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // First failure -> reconnect after ~1s.
+    act(() => {
+      MockEventSource.instances[0].onerror?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1250);
+    });
+    expect(MockEventSource.instances.length).toBe(2);
+
+    // That reconnection succeeds.
+    act(() => {
+      MockEventSource.instances[1].onopen?.();
+    });
+
+    // A subsequent failure should back off from ~1s again, not ~2s.
+    act(() => {
+      MockEventSource.instances[1].onerror?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1250);
+    });
+    expect(MockEventSource.instances.length).toBe(3);
   });
 });

--- a/fluxapay_frontend/src/hooks/usePaymentStatus.ts
+++ b/fluxapay_frontend/src/hooks/usePaymentStatus.ts
@@ -1,9 +1,71 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Payment } from '@/types/payment';
+import { z } from 'zod';
+import { Payment, PaymentStatus } from '@/types/payment';
+
+const PAYMENT_STATUSES = [
+  'pending',
+  'partially_paid',
+  'confirmed',
+  'overpaid',
+  'expired',
+  'failed',
+  'paid',
+  'completed',
+  'cancelled',
+  'refunded',
+  'partially_refunded',
+] as const satisfies readonly PaymentStatus[];
+
+/**
+ * Validates only the fields `normalizePaymentResponse` cannot safely default
+ * or derive — everything the rest of the app treats as required on a
+ * `Payment`. Extra/branding fields are handled separately below and are
+ * intentionally not part of this schema (`.passthrough()` lets them through
+ * untouched).
+ */
+const RequiredPaymentFieldsSchema = z
+  .object({
+    id: z.string().min(1, 'id is required'),
+    amount: z.number({ invalid_type_error: 'amount must be a number' }),
+    currency: z.string().min(1, 'currency is required'),
+    address: z.string().min(1, 'address is required'),
+    status: z.enum(PAYMENT_STATUSES),
+    expiresAt: z.string().min(1, 'expiresAt is required'),
+  })
+  .passthrough();
+
+/**
+ * Thrown by `normalizePaymentResponse` when the raw API response is missing
+ * (or has the wrong type for) a field the rest of the app requires on a
+ * `Payment`. Carries field-level details so callers can surface a specific
+ * message instead of an unhandled crash.
+ */
+export class PaymentParseError extends Error {
+  public readonly fieldErrors: Record<string, string[] | undefined>;
+
+  constructor(fieldErrors: Record<string, string[] | undefined>) {
+    const fields = Object.keys(fieldErrors).join(', ');
+    super(`Payment response is missing or has invalid required field(s): ${fields}`);
+    this.name = 'PaymentParseError';
+    this.fieldErrors = fieldErrors;
+  }
+}
 
 type ConnectionType = 'sse' | 'polling' | null;
+
+const SSE_RECONNECT_BASE_DELAY_MS = 1000;
+const SSE_RECONNECT_MAX_DELAY_MS = 30000;
+const SSE_MAX_CONSECUTIVE_FAILURES = 5;
+const SSE_RECONNECT_JITTER_RATIO = 0.2;
+
+/** Applies +/-20% jitter to a backoff delay so simultaneously-disconnected
+ *  clients don't all reconnect on the exact same tick (thundering herd). */
+function applyJitter(delayMs: number): number {
+  const jitter = delayMs * SSE_RECONNECT_JITTER_RATIO;
+  return delayMs + (Math.random() * 2 - 1) * jitter;
+}
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
@@ -30,9 +92,19 @@ export function normalizePaymentResponse(data: unknown): Payment {
   const raw = asRecord(data);
   const merchantBranding = asRecord(raw.merchant_branding ?? raw.merchantBranding);
 
+  const parsed = RequiredPaymentFieldsSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new PaymentParseError(parsed.error.flatten().fieldErrors);
+  }
+
+  const expiresAtDate = new Date(parsed.data.expiresAt);
+  if (Number.isNaN(expiresAtDate.getTime())) {
+    throw new PaymentParseError({ expiresAt: ['expiresAt is not a valid date'] });
+  }
+
   return {
-    ...(raw as unknown as Payment),
-    expiresAt: new Date(raw.expiresAt as string),
+    ...(parsed.data as unknown as Payment),
+    expiresAt: expiresAtDate,
     merchantName: firstString(
       raw.merchantName,
       raw.merchant_name,
@@ -105,6 +177,7 @@ export function usePaymentStatus(paymentId: string): UsePaymentStatusReturn {
   const paymentRef = useRef<Payment | null>(null);
   const pollingBackoffRef = useRef<number>(3000);
   const reconnectBackoffRef = useRef<number>(1000);
+  const sseFailureCountRef = useRef<number>(0);
 
   // Keep paymentRef in sync
   useEffect(() => {
@@ -257,73 +330,93 @@ export function usePaymentStatus(paymentId: string): UsePaymentStatusReturn {
       schedulePoll();
     };
 
-    const scheduleSseReconnect = () => {
-      if (cancelled || isOffline) return;
-      const delay = reconnectBackoffRef.current;
-      reconnectBackoffRef.current = Math.min(reconnectBackoffRef.current * 2, 30000);
-      setTimeout(() => {
-        if (cancelled) return;
+    const connectSse = () => {
+      if (cancelled) return;
+
+      let es: EventSource;
+      try {
+        es = new EventSource(`/api/payments/${paymentId}/stream`);
+      } catch {
+        // EventSource construction failed — fall back to polling
         startPollingFallback();
-      }, delay);
+        return;
+      }
+      eventSourceRef.current = es;
+
+      es.onopen = () => {
+        if (cancelled) return;
+        setConnectionType('sse');
+        // A successful connection resets the backoff and failure streak.
+        reconnectBackoffRef.current = SSE_RECONNECT_BASE_DELAY_MS;
+        sseFailureCountRef.current = 0;
+      };
+
+      es.onmessage = (event) => {
+        if (cancelled) return;
+        try {
+          const data = JSON.parse(event.data);
+          setPayment((prev) => {
+            if (!prev) return prev;
+            const statusChanged = prev.status !== data.status;
+            const paidAmountChanged = data.paidAmount !== undefined && prev.paidAmount !== data.paidAmount;
+            const addressChanged =
+              data.address !== undefined &&
+              typeof data.address === 'string' &&
+              data.address !== '' &&
+              prev.address !== data.address;
+            if (statusChanged || paidAmountChanged || addressChanged) {
+              if (addressChanged) {
+                setDepositAddressUpdated(true);
+              }
+              return {
+                ...prev,
+                status: data.status,
+                ...(data.paidAmount !== undefined ? { paidAmount: data.paidAmount } : {}),
+                ...(addressChanged ? { address: data.address as string } : {}),
+              };
+            }
+            return prev;
+          });
+
+          // Close SSE on terminal states
+          if (['confirmed', 'expired', 'failed', 'partially_paid', 'overpaid'].includes(data.status)) {
+            es.close();
+            eventSourceRef.current = null;
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      };
+
+      es.onerror = () => {
+        if (cancelled) return;
+        es.close();
+        eventSourceRef.current = null;
+
+        sseFailureCountRef.current += 1;
+        if (sseFailureCountRef.current >= SSE_MAX_CONSECUTIVE_FAILURES) {
+          startPollingFallback();
+          return;
+        }
+
+        // Exponential backoff (1s -> 2s -> 4s ... capped at 30s) with +/-20%
+        // jitter, so many simultaneously-dropped clients don't all retry on
+        // the same tick and flood the server (thundering herd).
+        const delay = applyJitter(reconnectBackoffRef.current);
+        reconnectBackoffRef.current = Math.min(
+          reconnectBackoffRef.current * 2,
+          SSE_RECONNECT_MAX_DELAY_MS,
+        );
+        setTimeout(() => {
+          if (cancelled) return;
+          connectSse();
+        }, delay);
+      };
     };
 
     // Try SSE first
     if (typeof window !== 'undefined' && 'EventSource' in window) {
-      try {
-        const es = new EventSource(`/api/payments/${paymentId}/stream`);
-        eventSourceRef.current = es;
-
-        es.onopen = () => {
-          if (!cancelled) setConnectionType('sse');
-        };
-
-        es.onmessage = (event) => {
-          if (cancelled) return;
-          try {
-            const data = JSON.parse(event.data);
-            setPayment((prev) => {
-              if (!prev) return prev;
-              const statusChanged = prev.status !== data.status;
-              const paidAmountChanged = data.paidAmount !== undefined && prev.paidAmount !== data.paidAmount;
-              const addressChanged =
-                data.address !== undefined &&
-                typeof data.address === 'string' &&
-                data.address !== '' &&
-                prev.address !== data.address;
-              if (statusChanged || paidAmountChanged || addressChanged) {
-                if (addressChanged) {
-                  setDepositAddressUpdated(true);
-                }
-                return {
-                  ...prev,
-                  status: data.status,
-                  ...(data.paidAmount !== undefined ? { paidAmount: data.paidAmount } : {}),
-                  ...(addressChanged ? { address: data.address as string } : {}),
-                };
-              }
-              return prev;
-            });
-
-            // Close SSE on terminal states
-            if (['confirmed', 'expired', 'failed', 'partially_paid', 'overpaid'].includes(data.status)) {
-              es.close();
-              eventSourceRef.current = null;
-            }
-          } catch {
-            // Ignore parse errors
-          }
-        };
-
-        es.onerror = () => {
-          // SSE failed — close and fall back to polling
-          es.close();
-          eventSourceRef.current = null;
-          scheduleSseReconnect();
-        };
-      } catch {
-        // EventSource construction failed — fall back to polling
-        startPollingFallback();
-      }
+      connectSse();
     } else {
       // No EventSource support — use polling
       startPollingFallback();


### PR DESCRIPTION
## Summary

Closes #827. Closes #828. Closes #829. Closes #830.

Four Stellar Wave issues assigned to me in this repo, batched into one PR per request.

### #827 — KYC magic-byte validation
`validateKycUploadFile()` now reads the file's actual magic bytes via `file-type` and rejects it (400) if they don't match the declared `mimetype`, in addition to the existing MIME-allowlist/size checks (422). A spoofed `Content-Type` header alone no longer passes. Updated the `kyc.service.ts` caller to `await` the now-async function, and rewrote `kyc.service.test.ts` with real magic-byte fixtures (JPEG/PNG/PDF/EXE), including the exact renamed-`.exe`-declaring-`image/jpeg` case from the issue.

### #828 — subscription renewal at current plan price
`processBillingCycle()` now charges `subscription.plan.amount` (fetched live every cycle) instead of leaving renewals pinned to a stale historical value. Added `MerchantSubscription.current_period_amount` (schema + migration), set at creation and refreshed every renewal. Added `sendUpcomingSubscriptionPriceChangeNotices()` — a new daily cron job wired into `cron.service.ts` — that emails merchants 7 days ahead of a renewal whose plan price increased, idempotent via `price_change_notice_sent_at` and guarded by a `CronLock`, following the same pattern as the existing payment-expiry-reminder job. New `plan.service.test.ts` covers the literal issue scenario (price 10 → 15, renewal charges 15) plus the notice job's increase/no-change/opted-out paths.

### #829 — SSE reconnect backoff
`usePaymentStatus`'s SSE error handler previously fell straight to polling after a single failure, with only a fixed delay before switching — it never actually retried SSE. It now retries the SSE connection itself: 1s → 2s → 4s → 8s → 16s (capped at 30s) with ±20% jitter, falling back to polling only after 5 consecutive failures, and resets both the backoff and failure count on a successful reconnection. Added hook-level tests (fake timers + a mock `EventSource`) asserting the jittered exponential sequence, the 5-failure polling fallback, and the backoff reset on success.

### #830 — validate normalizePaymentResponse
`normalizePaymentResponse()` previously spread the raw API response untyped and unchecked; a missing required field produced a partially-typed `Payment` that crashed the checkout page. Added a Zod schema validating exactly the fields the rest of the app requires (`id`/`amount`/`currency`/`address`/`status`/`expiresAt`), passthrough for everything else, and a new `PaymentParseError` with field-level details thrown on failure. `usePaymentStatus`'s existing `fetchPayment` try/catch already turns any thrown `Error` into hook `error` state, and the checkout page already renders an error UI whenever `error` is set — so both flow through with no further changes needed there. Added tests for missing-field, bad-enum, bad-date, and empty-response cases, plus a happy path.

No install/build/test run was performed for this PR (current task scope) — all four fixes were implemented and reviewed by inspection against this repo's existing test conventions (Jest for backend, Vitest + Testing Library for frontend) and mocking patterns.

## Test plan

- [ ] Maintainer: `cd fluxapay_backend && npm test` — covers #827 and #828.
- [ ] Maintainer: `cd fluxapay_frontend && npm test` — covers #829 and #830.
- [ ] Maintainer: `npx prisma migrate deploy` (or equivalent) to apply the new `current_period_amount`/`price_change_notice_sent_at` columns.