### PR TITLE
fix(sweep): isolate per-payment errors so a single failure does not a…

### DIFF
--- a/fluxapay_backend/prisma/migrations/20260727000000_add_sweep_retry_tracking/migration.sql
+++ b/fluxapay_backend/prisma/migrations/20260727000000_add_sweep_retry_tracking/migration.sql
@@ -1,0 +1,15 @@
+-- Add per-payment sweep retry tracking so a single failed sweep no longer
+-- silently vanishes into the batch's `skipped` list with no persisted state.
+-- Closes #824 -- SweepService does not handle partial batch failures.
+
+ALTER TABLE "Payment"
+  ADD COLUMN IF NOT EXISTS "sweep_retry_count"         INTEGER   NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "sweep_last_error"           TEXT,
+  ADD COLUMN IF NOT EXISTS "sweep_failed_at"            TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "sweep_needs_manual_review"  BOOLEAN   NOT NULL DEFAULT FALSE;
+
+-- The sweep-eligibility query now also excludes payments flagged for manual
+-- review, so the composite index gains that column too.
+DROP INDEX IF EXISTS "Payment_swept_status_idx";
+CREATE INDEX IF NOT EXISTS "Payment_swept_status_sweep_needs_manual_review_idx"
+  ON "Payment"("swept", "status", "sweep_needs_manual_review");

--- a/fluxapay_backend/prisma/schema.prisma
+++ b/fluxapay_backend/prisma/schema.prisma
@@ -374,6 +374,10 @@ model Payment {
   settled            Boolean  @default(false)
   swept_at           DateTime?
   sweep_tx_hash      String?
+  sweep_retry_count         Int      @default(0)
+  sweep_last_error          String?
+  sweep_failed_at           DateTime?
+  sweep_needs_manual_review Boolean  @default(false)
   confirmed_at       DateTime?
   settled_at         DateTime?
   settlement_ref     String?
@@ -403,7 +407,7 @@ model Payment {
   escrow_contract_address  String?
   escrow_status            String?
 
-  @@index([swept, status])
+  @@index([swept, status, sweep_needs_manual_review])
   @@index([customerId])
   @@index([merchantId, createdAt(sort: Desc)])
   @@index([merchantId, status, createdAt(sort: Desc)])

--- a/fluxapay_backend/src/config/__tests__/sweep.config.test.ts
+++ b/fluxapay_backend/src/config/__tests__/sweep.config.test.ts
@@ -1,4 +1,5 @@
 import {
+  getMaxSweepRetryAttempts,
   getSweepConfig,
   getSweepCronInterval,
   getSweepMinBalanceUsdc,
@@ -13,6 +14,7 @@ describe("sweep.config", () => {
     delete process.env.SWEEP_CRON_INTERVAL;
     delete process.env.SWEEP_CRON;
     delete process.env.SWEEP_MIN_BALANCE_USDC;
+    delete process.env.MAX_SWEEP_RETRY_ATTEMPTS;
   });
 
   afterEach(() => {
@@ -52,13 +54,39 @@ describe("sweep.config", () => {
     });
   });
 
+  describe("getMaxSweepRetryAttempts", () => {
+    it("defaults to 5 when unset", () => {
+      expect(getMaxSweepRetryAttempts()).toBe(5);
+    });
+
+    it("reads MAX_SWEEP_RETRY_ATTEMPTS from env", () => {
+      process.env.MAX_SWEEP_RETRY_ATTEMPTS = "3";
+      expect(getMaxSweepRetryAttempts()).toBe(3);
+    });
+
+    it("falls back to default for invalid values", () => {
+      process.env.MAX_SWEEP_RETRY_ATTEMPTS = "not-a-number";
+      expect(getMaxSweepRetryAttempts()).toBe(5);
+    });
+
+    it("falls back to default for zero or negative values", () => {
+      process.env.MAX_SWEEP_RETRY_ATTEMPTS = "0";
+      expect(getMaxSweepRetryAttempts()).toBe(5);
+
+      process.env.MAX_SWEEP_RETRY_ATTEMPTS = "-2";
+      expect(getMaxSweepRetryAttempts()).toBe(5);
+    });
+  });
+
   describe("getSweepConfig", () => {
-    it("returns interval and min balance together", () => {
+    it("returns interval, min balance, and max retry attempts together", () => {
       process.env.SWEEP_CRON_INTERVAL = "0 */2 * * *";
       process.env.SWEEP_MIN_BALANCE_USDC = "2";
+      process.env.MAX_SWEEP_RETRY_ATTEMPTS = "7";
       expect(getSweepConfig()).toEqual({
         cronInterval: "0 */2 * * *",
         minBalanceUsdc: 2,
+        maxSweepRetryAttempts: 7,
       });
     });
   });

--- a/fluxapay_backend/src/config/sweep.config.ts
+++ b/fluxapay_backend/src/config/sweep.config.ts
@@ -6,12 +6,15 @@
 
 const DEFAULT_SWEEP_CRON_INTERVAL = "0 * * * *";
 const DEFAULT_SWEEP_MIN_BALANCE_USDC = 0.5;
+const DEFAULT_MAX_SWEEP_RETRY_ATTEMPTS = 5;
 
 export interface SweepConfig {
   /** Cron expression for the scheduled sweep job. */
   cronInterval: string;
   /** Minimum on-chain USDC balance required before sweeping an address. */
   minBalanceUsdc: number;
+  /** Failed sweeps past this many attempts are flagged for manual review instead of retried. */
+  maxSweepRetryAttempts: number;
 }
 
 export function getSweepCronInterval(): string {
@@ -34,21 +37,36 @@ export function getSweepMinBalanceUsdc(): number {
   return parsed;
 }
 
+export function getMaxSweepRetryAttempts(): number {
+  const raw = process.env.MAX_SWEEP_RETRY_ATTEMPTS;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_MAX_SWEEP_RETRY_ATTEMPTS;
+  }
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_MAX_SWEEP_RETRY_ATTEMPTS;
+  }
+  return parsed;
+}
+
 export function getSweepConfig(): SweepConfig {
   return {
     cronInterval: getSweepCronInterval(),
     minBalanceUsdc: getSweepMinBalanceUsdc(),
+    maxSweepRetryAttempts: getMaxSweepRetryAttempts(),
   };
 }
 
 export function logSweepConfigAtStartup(): void {
-  const { cronInterval, minBalanceUsdc } = getSweepConfig();
+  const { cronInterval, minBalanceUsdc, maxSweepRetryAttempts } =
+    getSweepConfig();
   console.log(
     JSON.stringify({
       level: "info",
       message: "Sweep configuration loaded",
       sweepCronInterval: cronInterval,
       sweepMinBalanceUsdc: minBalanceUsdc,
+      maxSweepRetryAttempts,
     }),
   );
 }

--- a/fluxapay_backend/src/services/__tests__/sweep.service.test.ts
+++ b/fluxapay_backend/src/services/__tests__/sweep.service.test.ts
@@ -34,6 +34,7 @@ jest.mock("../../generated/client/client", () => ({
 jest.mock("../audit.service", () => ({
   logSweepTrigger: jest.fn().mockResolvedValue({ id: "audit_test" }),
   updateSweepCompletion: jest.fn().mockResolvedValue(undefined),
+  logSweepFailure: jest.fn().mockResolvedValue({ id: "audit_fail_test" }),
 }));
 
 jest.mock("../sweepQueue.service", () => ({
@@ -55,11 +56,13 @@ jest.mock("../HDWalletService", () => ({
 
 jest.mock("../../config/sweep.config", () => ({
   getSweepMinBalanceUsdc: jest.fn(() => 10),
+  getMaxSweepRetryAttempts: jest.fn(() => 5),
 }));
 
 // Import after mocks
 import { Horizon, Keypair, Account } from "@stellar/stellar-sdk";
 import { SweepService } from "../sweep.service";
+import { logSweepFailure } from "../audit.service";
 
 describe("SweepService", () => {
   let sweepService: SweepService;
@@ -355,6 +358,179 @@ describe("SweepService", () => {
       expect(mockServer.submitTransaction).toHaveBeenCalledTimes(3); // Max retries
       expect(result.addressesSwept).toBe(0);
       expect(result.skipped).toHaveLength(1);
+    });
+  });
+
+  describe("per-payment error isolation (#824)", () => {
+    it("isolates a single failing sweep: batch of 5 payments with 1 failing completes the other 4", async () => {
+      const fixtures = Array.from({ length: 5 }, (_, i) =>
+        createSweepFixture({
+          id: `payment_${i}`,
+          derivation_path: `m/44'/148'/0'/0/${i}`,
+        }),
+      );
+      const failingFixture = fixtures[2];
+
+      mockPrisma.payment.findMany.mockResolvedValue(
+        fixtures.map((f) => f.payment),
+      );
+
+      mockHDWalletService.regenerateKeypairFromPath.mockImplementation(
+        async (path: string) => {
+          const fixture = fixtures.find(
+            (f) => f.payment.derivation_path === path,
+          );
+          return fixture!.keypair;
+        },
+      );
+
+      mockServer.loadAccount.mockImplementation(async (publicKey: string) => {
+        const fixture = fixtures.find((f) => f.keypair.publicKey === publicKey);
+        return fixture!.account;
+      });
+
+      mockServer.submitTransaction.mockImplementation(async (tx: any) => {
+        if (tx.source === failingFixture.keypair.publicKey) {
+          throw new Error("insufficient XLM for fee");
+        }
+        return { hash: `tx_hash_${tx.source}` };
+      });
+
+      const result = await sweepService.sweepPaidPayments({
+        adminId: "admin_1",
+      });
+
+      expect(result.addressesSwept).toBe(4);
+      expect(result.txHashes).toHaveLength(4);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].paymentId).toBe(failingFixture.payment.id);
+
+      // The failing payment's retry bookkeeping was persisted...
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+        where: { id: failingFixture.payment.id },
+        data: {
+          sweep_retry_count: 1,
+          sweep_last_error: expect.stringContaining("insufficient XLM"),
+          sweep_failed_at: expect.any(Date),
+          sweep_needs_manual_review: false,
+        },
+      });
+
+      // ...and the other 4 were still marked swept despite the one failure.
+      const successfulIds = fixtures
+        .filter((f) => f.payment.id !== failingFixture.payment.id)
+        .map((f) => f.payment.id);
+      for (const id of successfulIds) {
+        expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+          where: { id },
+          data: {
+            swept: true,
+            swept_at: expect.any(Date),
+            sweep_tx_hash: expect.any(String),
+          },
+        });
+      }
+    });
+
+    it("increments sweep_retry_count and logs an audit entry on a failed sweep", async () => {
+      const { payment, keypair, account } = createSweepFixture({
+        sweep_retry_count: 2,
+      });
+
+      mockPrisma.payment.findMany.mockResolvedValue([payment]);
+      mockHDWalletService.regenerateKeypairFromPath.mockResolvedValue(keypair);
+      mockServer.loadAccount.mockResolvedValue(account);
+      mockServer.submitTransaction.mockRejectedValue(
+        new Error("invalid trustline"),
+      );
+
+      const result = await sweepService.sweepPaidPayments({
+        adminId: "admin_1",
+      });
+
+      expect(result.addressesSwept).toBe(0);
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+        where: { id: payment.id },
+        data: {
+          sweep_retry_count: 3,
+          sweep_last_error: expect.stringContaining("invalid trustline"),
+          sweep_failed_at: expect.any(Date),
+          sweep_needs_manual_review: false,
+        },
+      });
+      expect(logSweepFailure).toHaveBeenCalledWith({
+        paymentId: payment.id,
+        error: expect.stringContaining("invalid trustline"),
+        retryCount: 3,
+        flaggedForManualReview: false,
+      });
+    });
+
+    it("flags a payment for manual review once max retry attempts are reached", async () => {
+      const { payment, keypair, account } = createSweepFixture({
+        sweep_retry_count: 4,
+      });
+
+      mockPrisma.payment.findMany.mockResolvedValue([payment]);
+      mockHDWalletService.regenerateKeypairFromPath.mockResolvedValue(keypair);
+      mockServer.loadAccount.mockResolvedValue(account);
+      mockServer.submitTransaction.mockRejectedValue(new Error("tx_failed"));
+
+      await sweepService.sweepPaidPayments({ adminId: "admin_1" });
+
+      // getMaxSweepRetryAttempts() is mocked to 5, so the 5th failure flips the flag.
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+        where: { id: payment.id },
+        data: {
+          sweep_retry_count: 5,
+          sweep_last_error: expect.any(String),
+          sweep_failed_at: expect.any(Date),
+          sweep_needs_manual_review: true,
+        },
+      });
+      expect(logSweepFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          retryCount: 5,
+          flaggedForManualReview: true,
+        }),
+      );
+    });
+
+    it("excludes payments already flagged for manual review from the sweep query", async () => {
+      mockPrisma.payment.findMany.mockResolvedValue([]);
+
+      await sweepService.sweepPaidPayments({ adminId: "admin_1" });
+
+      expect(mockPrisma.payment.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            sweep_needs_manual_review: false,
+          }),
+        }),
+      );
+    });
+
+    it("does not abort the batch when persisting sweep-failure bookkeeping itself fails", async () => {
+      const { payment, keypair, account } = createSweepFixture();
+
+      mockPrisma.payment.findMany.mockResolvedValue([payment]);
+      mockHDWalletService.regenerateKeypairFromPath.mockResolvedValue(keypair);
+      mockServer.loadAccount.mockResolvedValue(account);
+      mockServer.submitTransaction.mockRejectedValue(new Error("tx_failed"));
+      mockPrisma.payment.update.mockRejectedValueOnce(
+        new Error("db unavailable"),
+      );
+      (logSweepFailure as jest.Mock).mockRejectedValueOnce(
+        new Error("audit unavailable"),
+      );
+
+      const result = await sweepService.sweepPaidPayments({
+        adminId: "admin_1",
+      });
+
+      expect(result.addressesSwept).toBe(0);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].paymentId).toBe(payment.id);
     });
   });
 

--- a/fluxapay_backend/src/services/audit.service.ts
+++ b/fluxapay_backend/src/services/audit.service.ts
@@ -392,6 +392,36 @@ export async function updateSweepCompletion(params: {
 }
 
 /**
+ * Log a single payment's sweep failure. Called per-payment from within the
+ * sweep batch loop, so callers must catch/ignore rejections themselves
+ * (safeAuditLog throws after exhausting retries) rather than letting a
+ * logging failure abort the batch.
+ */
+export async function logSweepFailure(params: {
+  paymentId: string;
+  error: string;
+  retryCount: number;
+  flaggedForManualReview: boolean;
+}): Promise<any | null> {
+  const details: SweepOperationDetails = {
+    sweep_type: "payment_sweep",
+    trigger_reason: params.paymentId,
+    status: "failed",
+    failure_reason: params.error,
+    retry_count: params.retryCount,
+    flagged_for_manual_review: params.flaggedForManualReview,
+  };
+
+  return await createAuditLog({
+    admin_id: "system",
+    action_type: AuditActionType.sweep_fail,
+    entity_type: AuditEntityType.sweep_operation,
+    entity_id: params.paymentId,
+    details,
+  });
+}
+
+/**
  * Log settlement batch initiation
  */
 export async function logSettlementBatch(params: {

--- a/fluxapay_backend/src/services/sweep.service.ts
+++ b/fluxapay_backend/src/services/sweep.service.ts
@@ -9,10 +9,17 @@ import {
 import { PrismaClient } from "../generated/client/client";
 import { Decimal } from "@prisma/client/runtime/library";
 import { HDWalletService } from "./HDWalletService";
-import { logSweepTrigger, updateSweepCompletion } from "./audit.service";
+import {
+  logSweepFailure,
+  logSweepTrigger,
+  updateSweepCompletion,
+} from "./audit.service";
 import { getLogger, getMetricsCollector } from "../utils/logger";
 import { sweepQueue } from "./sweepQueue.service";
-import { getSweepMinBalanceUsdc } from "../config/sweep.config";
+import {
+  getMaxSweepRetryAttempts,
+  getSweepMinBalanceUsdc,
+} from "../config/sweep.config";
 
 const prisma = new PrismaClient();
 
@@ -102,13 +109,17 @@ export class SweepService {
     this.hdWalletService = new HDWalletService();
   }
 
-  /** Identify eligible payments: confirmed/overpaid/paid, not swept, has derived address. */
+  /**
+   * Identify eligible payments: confirmed/overpaid/paid, not swept, has derived
+   * address, and not already flagged for manual review after exhausting retries.
+   */
   private async getUnsweptPaidPayments(limit: number) {
     return prisma.payment.findMany({
       where: {
         swept: false,
         stellar_address: { not: null },
         status: { in: ["confirmed", "overpaid", "paid"] },
+        sweep_needs_manual_review: false,
       },
       orderBy: { confirmed_at: "asc" },
       take: limit,
@@ -247,6 +258,7 @@ export class SweepService {
     });
 
     const payments = await this.getUnsweptPaidPayments(limit);
+    const maxSweepRetryAttempts = getMaxSweepRetryAttempts();
 
     const txHashes: string[] = [];
     const skipped: Array<{ paymentId: string; reason: string }> = [];
@@ -376,8 +388,55 @@ export class SweepService {
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           skipped.push({ paymentId: p.id, reason: msg });
-          if (dryRun)
+
+          if (dryRun) {
             decisions.push({ paymentId: p.id, action: "skip", reason: msg });
+            return;
+          }
+
+          // Per-payment error isolation (#824): a failed sweep must never
+          // abort the batch. Persisting the retry count / manual-review flag
+          // and writing the audit log are themselves guarded so that a
+          // failure in this bookkeeping can't become a new way to do that.
+          const nextRetryCount = (p.sweep_retry_count ?? 0) + 1;
+          const needsManualReview = nextRetryCount >= maxSweepRetryAttempts;
+
+          try {
+            await prisma.payment.update({
+              where: { id: p.id },
+              data: {
+                sweep_retry_count: nextRetryCount,
+                sweep_last_error: msg.slice(0, 500),
+                sweep_failed_at: new Date(),
+                sweep_needs_manual_review: needsManualReview,
+              },
+            });
+          } catch (updateErr: unknown) {
+            this.logger.error("Failed to persist sweep retry tracking", {
+              paymentId: p.id,
+              error:
+                updateErr instanceof Error
+                  ? updateErr.message
+                  : String(updateErr),
+            });
+          }
+
+          try {
+            await logSweepFailure({
+              paymentId: p.id,
+              error: msg,
+              retryCount: nextRetryCount,
+              flaggedForManualReview: needsManualReview,
+            });
+          } catch (auditErr: unknown) {
+            this.logger.error("Failed to write sweep failure audit log", {
+              paymentId: p.id,
+              error:
+                auditErr instanceof Error
+                  ? auditErr.message
+                  : String(auditErr),
+            });
+          }
         }
       };
 

--- a/fluxapay_backend/src/types/audit.types.ts
+++ b/fluxapay_backend/src/types/audit.types.ts
@@ -76,6 +76,8 @@ export interface SweepOperationDetails {
     transaction_hash?: string;
   };
   failure_reason?: string;
+  retry_count?: number;
+  flagged_for_manual_review?: boolean;
 }
 
 export interface SettlementBatchDetails {


### PR DESCRIPTION
…bort the full batch

SweepService already caught per-payment errors and used Promise.allSettled, so one bad Stellar tx couldn't actually abort the whole batch. What was missing was persisted state for a failed sweep: retries were silently forgotten between runs, there was no way to stop retrying forever, and failures left no audit trail.

- Add sweep_retry_count, sweep_last_error, sweep_failed_at, and sweep_needs_manual_review to Payment (+ migration).
- Add getMaxSweepRetryAttempts() (MAX_SWEEP_RETRY_ATTEMPTS, default 5).
- On a per-payment sweep failure: increment sweep_retry_count, record the error, flag sweep_needs_manual_review once the max is reached, and write a sweep_fail audit log entry via the new logSweepFailure().
- Exclude manually-flagged payments from getUnsweptPaidPayments so they stop being retried automatically.
- The new bookkeeping (DB update + audit log) is itself wrapped so that a failure to persist it can't become a new way to abort the batch.
- Add a unit test for the ticket's acceptance criteria: a batch of 5 payments with 1 failing sweep completes the other 4.

Closes #824