### PR TITLE
feat(auth): add IP-level brute force protection alongside existing pe…

### DIFF
--- a/fluxapay_backend/src/services/__tests__/auth.service.test.ts
+++ b/fluxapay_backend/src/services/__tests__/auth.service.test.ts
@@ -9,6 +9,7 @@ import {
   cleanupOldLoginAttempts,
 } from "../auth.service";
 import { PrismaClient } from "../../generated/client/client";
+import { ErrorCode } from "../../types/errors";
 import bcrypt from "bcrypt";
 
 process.env.DATABASE_URL =
@@ -62,8 +63,16 @@ describe("Auth Service", () => {
           { email: { contains: "test-lockout" } },
           { email: { contains: "test-notlocked" } },
           { email: { contains: "test-cleanup" } },
+          // Dedicated IP range used by the #825 IP-lockout tests below —
+          // distinct from 127.0.0.1 (shared by the other tests in this file)
+          // so a distributed-attack fixture never counts toward the other
+          // tests' per-IP failed-attempt totals, or vice versa.
+          { ip_address: { startsWith: "203.0.113." } },
         ],
       },
+    });
+    await prisma.rateLimitLog.deleteMany({
+      where: { ip_address: { startsWith: "203.0.113." } },
     });
     await prisma.merchant.deleteMany({ where: merchantFilter });
   });
@@ -189,6 +198,136 @@ describe("Auth Service", () => {
         status: 403,
         message: "Account not active",
       });
+    });
+
+    it("should lock out an IP after exceeding the IP-level failed-attempt threshold across different emails (#825)", async () => {
+      const attackerIp = "203.0.113.11";
+
+      // Seed 20 failed attempts across 20 different emails, all from the same
+      // IP — a distributed brute-force attack that per-email lockout alone
+      // (scoped to a single email) would never catch.
+      for (let i = 0; i < 20; i++) {
+        await prisma.loginAttempt.create({
+          data: {
+            merchantId: "unknown",
+            email: `distributed-target-${i}@example.com`,
+            ip_address: attackerIp,
+            success: false,
+          },
+        });
+      }
+
+      await expect(
+        loginWithEmailPassword({
+          email: "yet-another-target@example.com",
+          password: "whatever",
+          ipAddress: attackerIp,
+        })
+      ).rejects.toMatchObject({
+        status: 429,
+        code: ErrorCode.RATE_LIMIT_EXCEEDED,
+        message: expect.stringContaining("Too many failed login attempts from this IP"),
+        retryAfterSeconds: expect.any(Number),
+      });
+
+      const rateLimitLogs = await prisma.rateLimitLog.findMany({
+        where: { ip_address: attackerIp, limit_type: "login_ip_lockout" },
+      });
+      expect(rateLimitLogs.length).toBeGreaterThan(0);
+    });
+
+    it("should return 429 when both per-email and per-IP thresholds are exceeded simultaneously", async () => {
+      const sharedIp = "203.0.113.12";
+      const targetEmail = "test-auth-both-locked@example.com";
+
+      const hashedPassword = await bcrypt.hash("TestPassword123!", 12);
+      await prisma.merchant.create({
+        data: {
+          business_name: "Test Auth Merchant",
+          email: targetEmail,
+          phone_number: uniquePhone(),
+          country: "US",
+          settlement_currency: "USD",
+          password: hashedPassword,
+          webhook_secret: "test-secret",
+          status: "active",
+        },
+      });
+
+      // Exceed the per-email threshold (10) targeting this one email...
+      for (let i = 0; i < 10; i++) {
+        await prisma.loginAttempt.create({
+          data: {
+            merchantId: "unknown",
+            email: targetEmail,
+            ip_address: sharedIp,
+            success: false,
+          },
+        });
+      }
+      // ...and separately exceed the per-IP threshold (20) via other emails
+      // attempted from the same IP.
+      for (let i = 0; i < 15; i++) {
+        await prisma.loginAttempt.create({
+          data: {
+            merchantId: "unknown",
+            email: `other-target-${i}@example.com`,
+            ip_address: sharedIp,
+            success: false,
+          },
+        });
+      }
+
+      await expect(
+        loginWithEmailPassword({
+          email: targetEmail,
+          password: "TestPassword123!",
+          ipAddress: sharedIp,
+        })
+      ).rejects.toMatchObject({
+        status: 429,
+        code: ErrorCode.RATE_LIMIT_EXCEEDED,
+        // The IP check runs first, so it takes precedence when both are tripped.
+        message: expect.stringContaining("Too many failed login attempts from this IP"),
+      });
+    });
+
+    it("should respect AUTH_IP_LOCKOUT_THRESHOLD and AUTH_IP_LOCKOUT_WINDOW_MINUTES env overrides", async () => {
+      const originalThreshold = process.env.AUTH_IP_LOCKOUT_THRESHOLD;
+      const originalWindow = process.env.AUTH_IP_LOCKOUT_WINDOW_MINUTES;
+      process.env.AUTH_IP_LOCKOUT_THRESHOLD = "3";
+      process.env.AUTH_IP_LOCKOUT_WINDOW_MINUTES = "15";
+
+      try {
+        const configuredIp = "203.0.113.13";
+        for (let i = 0; i < 3; i++) {
+          await prisma.loginAttempt.create({
+            data: {
+              merchantId: "unknown",
+              email: `configured-target-${i}@example.com`,
+              ip_address: configuredIp,
+              success: false,
+            },
+          });
+        }
+
+        await expect(
+          loginWithEmailPassword({
+            email: "configured-target-new@example.com",
+            password: "whatever",
+            ipAddress: configuredIp,
+          })
+        ).rejects.toMatchObject({
+          status: 429,
+          code: ErrorCode.RATE_LIMIT_EXCEEDED,
+          retryAfterSeconds: 15 * 60,
+        });
+      } finally {
+        if (originalThreshold === undefined) delete process.env.AUTH_IP_LOCKOUT_THRESHOLD;
+        else process.env.AUTH_IP_LOCKOUT_THRESHOLD = originalThreshold;
+        if (originalWindow === undefined) delete process.env.AUTH_IP_LOCKOUT_WINDOW_MINUTES;
+        else process.env.AUTH_IP_LOCKOUT_WINDOW_MINUTES = originalWindow;
+      }
     });
   });
 

--- a/fluxapay_backend/src/services/auth.service.ts
+++ b/fluxapay_backend/src/services/auth.service.ts
@@ -11,10 +11,52 @@ const REFRESH_TOKEN_EXPIRY_DAYS = 30;
 const FAILED_LOGIN_THRESHOLD = 10;
 const ACCOUNT_LOCKOUT_MINUTES = 15;
 const BCRYPT_COST = 12;
+const DEFAULT_IP_LOCKOUT_THRESHOLD = 20;
+const DEFAULT_IP_LOCKOUT_WINDOW_MINUTES = 15;
+
+/** Max failed login attempts per IP (across all emails) before a 429 lockout. Env-configurable. */
+function getIpLockoutThreshold(): number {
+  const raw = parseInt(process.env.AUTH_IP_LOCKOUT_THRESHOLD ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_IP_LOCKOUT_THRESHOLD;
+}
+
+/** Rolling window (minutes) over which failed attempts count toward the IP lockout. Env-configurable. */
+function getIpLockoutWindowMinutes(): number {
+  const raw = parseInt(process.env.AUTH_IP_LOCKOUT_WINDOW_MINUTES ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_IP_LOCKOUT_WINDOW_MINUTES;
+}
+
+/**
+ * Persist an IP-level lockout event to RateLimitLog (distinct limit_type from
+ * the generic `authRateLimit` middleware and from per-email lockouts) so
+ * IP-level brute-force blocks can be monitored/audited separately.
+ */
+async function logIpLockoutEvent(params: {
+  ipAddress: string;
+  retryAfterSeconds: number;
+}): Promise<void> {
+  try {
+    await prisma.rateLimitLog.create({
+      data: {
+        ip_address: params.ipAddress,
+        endpoint: "auth.loginWithEmailPassword",
+        limit_type: "login_ip_lockout",
+        retry_after_seconds: params.retryAfterSeconds,
+        timestamp: new Date(),
+      },
+    });
+  } catch (error) {
+    console.error("Failed to log IP lockout event:", error);
+  }
+}
 
 /**
  * Login with email and password, returns access token and refresh token
- * Implements account lockout after 10 failed attempts within 15 minutes
+ * Implements two layers of brute-force protection:
+ *  - Per-email lockout after 10 failed attempts within 15 minutes.
+ *  - Per-IP lockout (across all emails) after AUTH_IP_LOCKOUT_THRESHOLD failed
+ *    attempts within AUTH_IP_LOCKOUT_WINDOW_MINUTES, to catch a distributed
+ *    attack that spreads failed attempts across many emails from one IP.
  */
 export async function loginWithEmailPassword(data: {
   email: string;
@@ -23,6 +65,45 @@ export async function loginWithEmailPassword(data: {
   userAgent?: string;
 }) {
   const { email, password, ipAddress, userAgent } = data;
+  const ip = ipAddress || "unknown";
+
+  // Check for IP-level lockout first — this catches a distributed brute-force
+  // attack (many emails, one IP) that the per-email check alone would miss.
+  const ipLockoutThreshold = getIpLockoutThreshold();
+  const ipLockoutWindowMinutes = getIpLockoutWindowMinutes();
+
+  const recentFailedAttemptsForIp = await prisma.loginAttempt.count({
+    where: {
+      ip_address: ip,
+      success: false,
+      created_at: {
+        gte: new Date(Date.now() - ipLockoutWindowMinutes * 60 * 1000),
+      },
+    },
+  });
+
+  if (recentFailedAttemptsForIp >= ipLockoutThreshold) {
+    const retryAfterSeconds = ipLockoutWindowMinutes * 60;
+
+    // Log this attempt as failed
+    await prisma.loginAttempt.create({
+      data: {
+        merchantId: "unknown",
+        email,
+        ip_address: ip,
+        success: false,
+      },
+    });
+
+    await logIpLockoutEvent({ ipAddress: ip, retryAfterSeconds });
+
+    throw apiError(
+      429,
+      ErrorCode.RATE_LIMIT_EXCEEDED,
+      "Too many failed login attempts from this IP address. Please try again later.",
+      { retryAfterSeconds },
+    );
+  }
 
   // Check for account lockout
   const recentFailedAttempts = await prisma.loginAttempt.findMany({
@@ -41,7 +122,7 @@ export async function loginWithEmailPassword(data: {
       data: {
         merchantId: "unknown",
         email,
-        ip_address: ipAddress || "unknown",
+        ip_address: ip,
         success: false,
       },
     });


### PR DESCRIPTION
…r-email lockout

loginWithEmailPassword() only counted failed LoginAttempt rows by email, so a distributed attack spreading failed attempts across many emails from one IP could never trip the per-email lockout, and there was no IP-level check at all.

- Add an IP-level check (across all emails) using the same LoginAttempt table: max AUTH_IP_LOCKOUT_THRESHOLD (default 20) failed attempts per IP within AUTH_IP_LOCKOUT_WINDOW_MINUTES (default 15), both env-configurable.
- The IP check runs before the per-email check (and before the merchant lookup), so a blocked IP never leaks whether a given email exists.
- On IP lockout: return 429 RATE_LIMIT_EXCEEDED with Retry-After, and log the event to RateLimitLog with limit_type "login_ip_lockout" — distinct from per-email lockouts and from the generic authRateLimit middleware — so IP-level brute-force blocks can be monitored separately.
- Per-email lockout threshold/behavior is unchanged.
- Add tests: IP lockout across many emails, both per-email and per-IP thresholds tripped simultaneously, and env var overrides for the IP threshold/window.

Closes #825