### PR TITLE
fix(metrics): expand normalizePath to prevent cardinality explosion

### DIFF
--- a/fluxapay_backend/load-tests/README.md
+++ b/fluxapay_backend/load-tests/README.md
@@ -46,3 +46,87 @@ STEADY_VUS=30 \
 THINK_TIME_SECONDS=1 \
 k6 run load-tests/k6-payment-create-list.js
 ```
+
+---
+
+## Webhook delivery scenario
+
+`k6-webhook-delivery.js` stress-tests the webhook re-delivery path — which
+makes outbound HTTP calls to merchant endpoints — under high concurrency.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `WEBHOOK_ID` | *(empty)* | Re-deliver a specific webhook config; omit to hit the `/webhooks/test` synthetic endpoint |
+| `THINK_TIME_SECONDS` | `0` | Sleep between iterations |
+
+### Targets
+
+- **100 VUs, 60 s** constant load.
+- p99 delivery latency **< 3 000 ms**.
+- Failure rate **< 2 %**.
+
+### Run
+
+```bash
+BASE_URL="https://api.staging.fluxapay.com" \
+API_KEY="sk_live_xxx" \
+k6 run load-tests/k6-webhook-delivery.js
+```
+
+To re-deliver a specific webhook:
+
+```bash
+BASE_URL="https://api.staging.fluxapay.com" \
+API_KEY="sk_live_xxx" \
+WEBHOOK_ID="wh_abc123" \
+k6 run load-tests/k6-webhook-delivery.js
+```
+
+---
+
+## Settlement batch scenario
+
+`k6-settlement-batch.js` simulates **50 merchants** triggering the settlement
+batch concurrently, exercising FX lookups and DB writes in parallel.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `MERCHANT_COUNT` | `50` | Number of concurrent VUs (one per merchant) |
+| `ITERATIONS` | `3` | Batch rounds per VU |
+| `THINK_TIME_SECONDS` | `1` | Sleep between rounds |
+
+### Targets
+
+- **50 VUs × 3 iterations** (`per-vu-iterations` executor, max 5 min).
+- p95 batch latency **< 5 000 ms**.
+- Failure rate **< 2 %**.
+
+### Run
+
+```bash
+BASE_URL="https://api.staging.fluxapay.com" \
+API_KEY="sk_live_xxx" \
+k6 run load-tests/k6-settlement-batch.js
+```
+
+---
+
+## CI integration
+
+The load tests are **not** run on every PR — they are designed to run
+optionally on tagged releases via the `production-deploy` workflow.
+
+To trigger them on a release tag, add a step similar to the following to
+`.github/workflows/production-deploy.yml` (or a dedicated `load-test.yml`):
+
+```yaml
+- name: Run load tests (tagged release only)
+  if: startsWith(github.ref, 'refs/tags/')
+  run: |
+    k6 run load-tests/k6-webhook-delivery.js
+    k6 run load-tests/k6-settlement-batch.js
+  env:
+    BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+    API_KEY:  ${{ secrets.STAGING_API_KEY }}
+    REQUIRE_STAGING_GUARD: "false"
+```

--- a/fluxapay_backend/load-tests/k6-settlement-batch.js
+++ b/fluxapay_backend/load-tests/k6-settlement-batch.js
@@ -1,0 +1,84 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+/**
+ * k6 Settlement Batch Load Test
+ *
+ * Simulates 50 merchant settlement operations running concurrently to stress
+ * the batch endpoint (FX lookups + DB writes).  Each VU represents one merchant.
+ *
+ * Required env vars:
+ *   BASE_URL   – e.g. https://api.staging.fluxapay.com
+ *   API_KEY    – service / admin API key with settlement:write scope
+ *
+ * Optional env vars:
+ *   MERCHANT_COUNT     – number of synthetic merchants / VUs (default 50)
+ *   ITERATIONS         – how many batch rounds per VU (default 3)
+ *   THINK_TIME_SECONDS – sleep between iterations (default 1)
+ *   REQUIRE_STAGING_GUARD – set to "false" to allow non-staging URLs
+ */
+
+const BASE_URL       = (__ENV.BASE_URL || "").replace(/\/$/, "");
+const API_KEY        = __ENV.API_KEY || "";
+const MERCHANT_COUNT = Number(__ENV.MERCHANT_COUNT || 50);
+const ITERATIONS     = Number(__ENV.ITERATIONS || 3);
+const THINK_TIME     = Number(__ENV.THINK_TIME_SECONDS || 1);
+const REQUIRE_STAGING_GUARD = (__ENV.REQUIRE_STAGING_GUARD || "true").toLowerCase() !== "false";
+
+if (!BASE_URL) throw new Error("BASE_URL is required");
+if (!API_KEY)  throw new Error("API_KEY is required");
+if (REQUIRE_STAGING_GUARD && !/staging/i.test(BASE_URL)) {
+  throw new Error(`Refusing to run against non-staging URL: ${BASE_URL}. Set REQUIRE_STAGING_GUARD=false to override.`);
+}
+
+const settlementLatency  = new Trend("settlement_batch_latency", true);
+const settlementFailures = new Rate("settlement_batch_failures");
+
+export const options = {
+  scenarios: {
+    settlement_batch: {
+      executor: "per-vu-iterations",
+      vus:        MERCHANT_COUNT,
+      iterations: ITERATIONS,
+      maxDuration: "5m",
+    },
+  },
+  thresholds: {
+    http_req_failed:           ["rate<0.02"],
+    settlement_batch_latency:  ["p(95)<5000"],
+    settlement_batch_failures: ["rate<0.02"],
+  },
+  summaryTrendStats: ["avg", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+function headers() {
+  return { "Content-Type": "application/json", "x-api-key": API_KEY };
+}
+
+export default function () {
+  // Each VU acts as a distinct merchant identified by its VU number
+  const merchantRef = `k6-merchant-${__VU}`;
+
+  const payload = JSON.stringify({
+    merchant_ref: merchantRef,
+    currency:     "USDC",
+    dry_run:      false,
+    metadata:     { source: "k6", vu: __VU, iter: __ITER },
+  });
+
+  const res = http.post(
+    `${BASE_URL}/api/v1/settlements/batch`,
+    payload,
+    { headers: headers(), tags: { name: "settlement_batch" } },
+  );
+
+  settlementLatency.add(res.timings.duration);
+
+  const ok = check(res, {
+    "settlement accepted (2xx)": (r) => r.status >= 200 && r.status < 300,
+  });
+  settlementFailures.add(!ok);
+
+  sleep(THINK_TIME);
+}

--- a/fluxapay_backend/load-tests/k6-webhook-delivery.js
+++ b/fluxapay_backend/load-tests/k6-webhook-delivery.js
@@ -1,0 +1,77 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+/**
+ * k6 Webhook Delivery Load Test
+ *
+ * Simulates 100 VUs hammering the internal webhook re-delivery endpoint for
+ * 60 seconds to measure p99 delivery latency under concurrency.
+ *
+ * Required env vars:
+ *   BASE_URL   – e.g. https://api.staging.fluxapay.com
+ *   API_KEY    – service / admin API key with webhook:write scope
+ *
+ * Optional env vars:
+ *   WEBHOOK_ID        – a real webhook config ID to re-trigger (default: uses
+ *                       the test endpoint which creates a synthetic delivery)
+ *   THINK_TIME_SECONDS – sleep between iterations (default 0)
+ *   REQUIRE_STAGING_GUARD – set to "false" to allow non-staging URLs
+ */
+
+const BASE_URL = (__ENV.BASE_URL || "").replace(/\/$/, "");
+const API_KEY = __ENV.API_KEY || "";
+const WEBHOOK_ID = __ENV.WEBHOOK_ID || "";
+const THINK_TIME = Number(__ENV.THINK_TIME_SECONDS || 0);
+const REQUIRE_STAGING_GUARD = (__ENV.REQUIRE_STAGING_GUARD || "true").toLowerCase() !== "false";
+
+if (!BASE_URL) throw new Error("BASE_URL is required");
+if (!API_KEY)  throw new Error("API_KEY is required");
+if (REQUIRE_STAGING_GUARD && !/staging/i.test(BASE_URL)) {
+  throw new Error(`Refusing to run against non-staging URL: ${BASE_URL}. Set REQUIRE_STAGING_GUARD=false to override.`);
+}
+
+const deliveryLatency = new Trend("webhook_delivery_latency", true);
+const deliveryFailures = new Rate("webhook_delivery_failures");
+
+export const options = {
+  scenarios: {
+    webhook_delivery: {
+      executor: "constant-vus",
+      vus: 100,
+      duration: "60s",
+    },
+  },
+  thresholds: {
+    http_req_failed:          ["rate<0.02"],
+    webhook_delivery_latency: ["p(99)<3000"],
+    webhook_delivery_failures:["rate<0.02"],
+  },
+  summaryTrendStats: ["avg", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+function headers() {
+  return { "Content-Type": "application/json", "x-api-key": API_KEY };
+}
+
+export default function () {
+  const url = WEBHOOK_ID
+    ? `${BASE_URL}/api/v1/webhooks/${WEBHOOK_ID}/redeliver`
+    : `${BASE_URL}/api/v1/webhooks/test`;
+
+  const payload = JSON.stringify({
+    event_type: "payment.completed",
+    payload: { id: `k6-${__VU}-${__ITER}`, amount: 100, currency: "USDC" },
+  });
+
+  const res = http.post(url, payload, { headers: headers(), tags: { name: "webhook_delivery" } });
+
+  deliveryLatency.add(res.timings.duration);
+
+  const ok = check(res, {
+    "delivery accepted (2xx)": (r) => r.status >= 200 && r.status < 300,
+  });
+  deliveryFailures.add(!ok);
+
+  if (THINK_TIME > 0) sleep(THINK_TIME);
+}

--- a/fluxapay_backend/src/middleware/requestLogging.middleware.ts
+++ b/fluxapay_backend/src/middleware/requestLogging.middleware.ts
@@ -170,16 +170,30 @@ function calculateDuration(startTime: [number, number]): number {
  * Normalize path to remove dynamic parameters for metrics
  * This prevents metric cardinality explosion
  */
+/**
+ * Normalize path to remove dynamic parameters for metrics.
+ * Prevents metric cardinality explosion from high-entropy path segments:
+ *   - UUIDs
+ *   - Numeric IDs
+ *   - Stellar public keys (56-char G... base58 strings)
+ *   - API key prefixes (sk_live_..., pk_test_..., etc.)
+ *   - Email addresses in paths
+ *   - Base64 / long opaque tokens (≥32 chars)
+ */
 function normalizePath(path: string): string {
-  // Remove query parameters
   const basePath = path.split('?')[0];
-  
-  // Replace UUIDs with placeholder
-  const normalized = basePath.replace(
-    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
-    ':id'
-  );
-  
-  // Replace numeric IDs with placeholder
-  return normalized.replace(/\/\d+/g, '/:id');
+
+  return basePath
+    // UUIDs
+    .replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '/:id')
+    // Numeric IDs
+    .replace(/\/\d+/g, '/:id')
+    // Stellar public keys: G followed by 55 base58 chars
+    .replace(/\/G[A-HJ-NP-Z2-7A-Z0-9]{55}/g, '/:stellarKey')
+    // API key prefixes (e.g. sk_live_..., pk_test_...)
+    .replace(/\/(?:sk|pk)_(?:live|test)_[A-Za-z0-9_-]+/g, '/:apiKey')
+    // Email addresses in path segments
+    .replace(/\/[^\s/]+@[^\s/]+\.[^\s/]+/g, '/:email')
+    // Long opaque tokens / base64 values (≥32 alphanumeric+_- chars)
+    .replace(/\/[A-Za-z0-9_-]{32,}/g, '/:token');
 }


### PR DESCRIPTION
closes #882 
closes #881 
closes #805 
closes #898 


Adds normalization for Stellar public keys, API key prefixes, email addresses, and long opaque tokens (base64/JWT) in addition to UUIDs and numeric IDs. Each unique high-entropy path segment was previously creating a new label combination in http_request_duration_ms, http_errors_total, and http_slow_requests_total — a Prometheus anti-pattern that can exhaust collector memory.