### PR TITLE
fix(admin): redirect non-admin users to login on 403 instead of rende…

### DIFF
--- a/fluxapay_frontend/e2e/admin-sweep-access-control.spec.ts
+++ b/fluxapay_frontend/e2e/admin-sweep-access-control.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E – Admin sweep page access control (#792)
+ * Asserts that a non-admin user who navigates directly to /admin/sweep
+ * is redirected to /login rather than seeing an empty page.
+ */
+test.describe("Admin sweep page access control", () => {
+  test("non-admin user navigating to /admin/sweep is redirected to /login", async ({
+    page,
+  }) => {
+    // Simulate a non-admin user: no admin flag, no auth token in storage.
+    await page.addInitScript(() => {
+      localStorage.removeItem("isAdmin");
+      localStorage.removeItem("token");
+      sessionStorage.removeItem("token");
+    });
+
+    // Guard against any real network call reaching the backend by mocking
+    // the sweep status endpoint to return 403 — matching the issue scenario.
+    await page.route("**/api/admin/sweep/status", (route) =>
+      route.fulfill({
+        status: 403,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Forbidden" }),
+      }),
+    );
+
+    await page.goto("/admin/sweep");
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 });
+  });
+});

--- a/fluxapay_frontend/src/app/admin/AdminGuard.tsx
+++ b/fluxapay_frontend/src/app/admin/AdminGuard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { Loader2, ShieldOff } from 'lucide-react';
 import { isAuthenticated, isAdmin } from '@/lib/auth';
 
@@ -15,6 +15,7 @@ const ADMIN_ENABLED = process.env.NEXT_PUBLIC_ADMIN_ENABLED === 'true';
  */
 export default function AdminGuard({ children }: { children: React.ReactNode }) {
     const router = useRouter();
+    const pathname = usePathname();
     const [checked, setChecked] = useState(!ADMIN_ENABLED);
 
     useEffect(() => {
@@ -28,7 +29,7 @@ export default function AdminGuard({ children }: { children: React.ReactNode }) 
             return;
         }
         setChecked(true);
-    }, [router]);
+    }, [router, pathname]);
 
     if (!checked) {
         return (

--- a/fluxapay_frontend/src/app/admin/sweep/page.tsx
+++ b/fluxapay_frontend/src/app/admin/sweep/page.tsx
@@ -18,6 +18,7 @@ import {
   Play,
 } from "lucide-react";
 import { api } from "@/lib/api";
+import { useRouter } from "next/navigation";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -141,6 +142,7 @@ function StatusPill({ status }: { status: string }) {
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function SweepPage() {
+  const router = useRouter();
   const [sweepStatus, setSweepStatus] = useState<SweepStatus | null>(null);
   const [statusLoading, setStatusLoading] = useState(true);
   const [statusError, setStatusError] = useState<string | null>(null);
@@ -185,6 +187,10 @@ export default function SweepPage() {
     try {
       const res = await api.sweep.getStatus();
       if (!res.ok) {
+        if (res.status === 403) {
+          router.replace('/login');
+          return;
+        }
         const err = await res
           .json()
           .catch(() => ({ message: "Unknown error" }));
@@ -198,7 +204,7 @@ export default function SweepPage() {
     } finally {
       setStatusLoading(false);
     }
-  }, []);
+  }, [router]);
 
   useEffect(() => {
     addLog("info", "Sweep Control Center loaded.");
@@ -212,6 +218,10 @@ export default function SweepPage() {
 
     try {
       const res = await api.sweep.previewSweep();
+      if (res.status === 403) {
+        router.replace('/login');
+        return;
+      }
       const data = await res.json();
       if (!res.ok) {
         throw new Error(data.message ?? data.error ?? `HTTP ${res.status}`);
@@ -248,6 +258,10 @@ export default function SweepPage() {
 
     try {
       const res = await api.sweep.runSweep(dryRun);
+      if (res.status === 403) {
+        router.replace('/login');
+        return;
+      }
       const data = await res.json();
       if (!res.ok) {
         throw new Error(data.message ?? data.error ?? `HTTP ${res.status}`);


### PR DESCRIPTION
Closes #792 

## fix(admin): redirect non-admin users to login on 403 instead of rendering empty page

### Problem

`/admin/sweep/page.tsx` is wrapped by `AdminGuard` in the layout, but two issues existed:

1. **`AdminGuard`** only ran its token check on initial mount — a user could bypass it by navigating directly to `/admin/sweep` via the browser address bar after the layout had already mounted.
2. **`sweep/page.tsx`** made three direct admin API calls (`getStatus`, `previewSweep`, `runSweep`). When those returned `403`, the page silently rendered empty/broken state instead of redirecting, exposing the treasury UI shell to non-admin users.

### Changes

#### `src/app/admin/AdminGuard.tsx`
- Imported `usePathname` from `next/navigation`.
- Called `usePathname()` in the component body and added `pathname` to the `useEffect` dependency array.
- The guard now re-validates `isAuthenticated() && isAdmin()` on **every client-side route change**, not just on first mount.

#### `src/app/admin/sweep/page.tsx`
- Imported `useRouter` from `next/navigation` and instantiated it at the top of `SweepPage`.
- Added a `403` early-return redirect (`router.replace('/login')`) in all three API call handlers:
  - `fetchStatus` — checked before parsing the error body.
  - `handlePreviewSweep` — checked before calling `res.json()`.
  - `handleTriggerSweep` — checked before calling `res.json()`.
- Updated `fetchStatus`'s `useCallback` dependency array from `[]` to `[router]`.

#### `e2e/admin-sweep-access-control.spec.ts` *(new)*
- Clears all auth/admin tokens from `localStorage` and `sessionStorage` via `addInitScript` to simulate a non-admin user.
- Mocks the sweep status endpoint
