### PR TITLE
test(python-sdk): cover sync context manager cleanup

### DIFF
--- a/fluxapay_python_sdk/README.md
+++ b/fluxapay_python_sdk/README.md
@@ -15,15 +15,14 @@ pip install fluxapay
 ```python
 from fluxapay import FluxaPay
 
-client = FluxaPay(api_key="sk_live_...")
-
-payment = client.payments.create(
-    amount=49.99,
-    currency="USD",
-    customer_email="buyer@example.com",
-    order_id="order_123",
-)
-print(payment.checkout_url)
+with FluxaPay(api_key="sk_live_...") as client:
+    payment = client.payments.create(
+        amount=49.99,
+        currency="USD",
+        customer_email="buyer@example.com",
+        order_id="order_123",
+    )
+    print(payment.checkout_url)
 ```
 
 ### Asynchronous

--- a/fluxapay_python_sdk/tests/test_sdk.py
+++ b/fluxapay_python_sdk/tests/test_sdk.py
@@ -100,6 +100,23 @@ def test_missing_api_key_raises():
         FluxaPay(api_key="")
 
 
+def test_sync_client_context_manager_closes_on_exit(monkeypatch):
+    client = FluxaPay(api_key=API_KEY)
+    closed = False
+
+    def close() -> None:
+        nonlocal closed
+        closed = True
+
+    monkeypatch.setattr(client, "close", close)
+
+    with client as active_client:
+        assert active_client is client
+        assert closed is False
+
+    assert closed is True
+
+
 # ── Async client ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #796

## Summary
- adds a regression test proving the sync `FluxaPay` context manager calls `close()` when a `with` block exits
- updates the Python SDK synchronous quick-start example to use `with FluxaPay(...) as client`

## Notes
The sync client already exposes `__enter__` / `__exit__` on current `main`, so this PR locks in the cleanup behavior and documents the intended usage.

## Verification
- `PYTHONPATH=fluxapay_python_sdk python -m pytest fluxapay_python_sdk/tests/test_sdk.py -q` -> 13 passed